### PR TITLE
Redirect `stderr` output to rtail

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -2,7 +2,7 @@ module.exports = {
   apps: [
     {
       name: 'minerva-dev',
-      script: 'node ./bundle.js | rtail --id minerva-dev',
+      script: 'node ./bundle.js 2>&1 | rtail --id minerva-dev',
       time: true,
       instances: 1,
       autorestart: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-console.log('Hello World');
+console.log('There is nothing here yet.');
+console.error('This is an error.');
+while (true) {}


### PR DESCRIPTION
We use rtail to allow us to view logs for our applications from browser. Currently, it only logs `stdout` output for minerva, which isn't very useful if any errors come up. This should hopefully fix it.

**Testing instructions**
- Deploy this branch to dev (`yarn run deploy-dev`)
- Go to rtail (DM me for the URL as it's not protected yet)
- Ensure that you see both the `console.log` message and the `console.error` message that's found in index.ts

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/41)
<!-- Reviewable:end -->
