### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default Reviewers
+* @QuantumManiac @Darth-Raazi @BluCodeGH
+# Project Contributors
+* @QuantumManiac @PCModeActivate @slightlyskepticalpotat @yxyyeah @Panizghi @billyao021031 @shirleyfyx @jeffrey-huang-yz @wxp02

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default Reviewers
-* @QuantumManiac @Darth-Raazi @BluCodeGH
+* @waterloo-rocketry/default-reviewers
 # Project Contributors
 * @QuantumManiac @PCModeActivate @slightlyskepticalpotat @yxyyeah @Panizghi @billyao021031 @shirleyfyx @jeffrey-huang-yz @wxp02


### PR DESCRIPTION
Closes #42 

Created a `CODEOWNERS` file. With this added, when a PR is created for this repo, users listed in the file will automatically be assigned as reviewers. 

This file consists of two sections: one for the "Default Reviewers", individuals who are usually assigned as reviewers to every software PR and not necessarily project contributors, and another section for the project contributors themselves.

This will be replacing the `minerva-rewriters` team that we're currently using for this purpose

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/46)
<!-- Reviewable:end -->
