### PR TITLE
Change `CODEOWNERS` order

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,2 @@
-# Default Reviewers
-* @waterloo-rocketry/default-reviewers
-# Project Contributors
-* @QuantumManiac @PCModeActivate @slightlyskepticalpotat @yxyyeah @Panizghi @billyao021031 @shirleyfyx @jeffrey-huang-yz @wxp02
+* @waterloo-rocketry/default-reviewers @QuantumManiac @PCModeActivate @slightlyskepticalpotat @yxyyeah @Panizghi @billyao021031 @shirleyfyx @jeffrey-huang-yz @wxp02
+


### PR DESCRIPTION
Later lines of the `CODEOWNERS` file takes precedence. Therefore, having two lines with a the "match all" (`*`) does not work as it will just use the later line to define it. This fix fixes it by putting all the "Catch-all" codeowners onto one line.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/49)
<!-- Reviewable:end -->
