### PR TITLE
Parse events from Google Calendar

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,13 +1,10 @@
 {
-    "parser": "@typescript-eslint/parser",
-    "extends": [
-      "plugin:@typescript-eslint/recommended",
-      "plugin:prettier/recommended"
-    ],
-    "plugins": ["@typescript-eslint", "prettier"],
-    "ignorePatterns": ["/dist/*", "/node_modules/*"],
-    "rules": {
-      "prettier/prettier": "error"
-    }
+  "parser": "@typescript-eslint/parser",
+  "extends": ["plugin:@typescript-eslint/recommended", "plugin:prettier/recommended"],
+  "plugins": ["@typescript-eslint", "prettier"],
+  "ignorePatterns": ["/dist/*", "/node_modules/*"],
+  "rules": {
+    "prettier/prettier": "error",
+    "@typescript-eslint/explicit-function-return-type": ["error"]
+  }
 }
-  

--- a/src/classes/CalendarEvent.ts
+++ b/src/classes/CalendarEvent.ts
@@ -36,10 +36,10 @@ export default class CalendarEvent {
   constructor(event: calendar_v3.Schema$Event, workspaceChannels: SlackChannel[]) {
     if (event.summary == undefined) throw new Error("Event summary is undefined");
     this.title = event.summary;
-    // if (event.start?.dateTime == undefined) throw new Error("Event start is undefined");
-    this.start = new Date(JSON.stringify(event.start?.dateTime));
-    // if (event.end?.dateTime == undefined) throw new Error("Event end is undefined");
-    this.end = new Date(JSON.stringify(event.end?.dateTime));
+    if (event.start?.dateTime == undefined) throw new Error("Event start is undefined");
+    this.start = new Date(event.start?.dateTime);
+    if (event.end?.dateTime == undefined) throw new Error("Event end is undefined");
+    this.end = new Date(event.end?.dateTime);
 
     this.location = event.location ?? undefined;
 

--- a/src/classes/CalendarEvent.ts
+++ b/src/classes/CalendarEvent.ts
@@ -36,10 +36,10 @@ export default class CalendarEvent {
   constructor(event: calendar_v3.Schema$Event, workspaceChannels: SlackChannel[]) {
     if (event.summary == undefined) throw new Error("Event summary is undefined");
     this.title = event.summary;
-    if (event.start?.dateTime == undefined) throw new Error("Event start is undefined");
-    this.start = new Date(event.start.dateTime);
-    if (event.end?.dateTime == undefined) throw new Error("Event end is undefined");
-    this.end = new Date(event.end.dateTime);
+    // if (event.start?.dateTime == undefined) throw new Error("Event start is undefined");
+    this.start = new Date(JSON.stringify(event.start?.dateTime));
+    // if (event.end?.dateTime == undefined) throw new Error("Event end is undefined");
+    this.end = new Date(JSON.stringify(event.end?.dateTime));
 
     this.location = event.location ?? undefined;
 

--- a/src/classes/CalendarEvent.ts
+++ b/src/classes/CalendarEvent.ts
@@ -37,9 +37,9 @@ export default class CalendarEvent {
     if (event.summary == undefined) throw new Error("Event summary is undefined");
     this.title = event.summary;
     if (event.start?.dateTime == undefined) throw new Error("Event start is undefined");
-    this.start = new Date(event.start?.dateTime);
+    this.start = new Date(event.start.dateTime);
     if (event.end?.dateTime == undefined) throw new Error("Event end is undefined");
-    this.end = new Date(event.end?.dateTime);
+    this.end = new Date(event.end.dateTime);
 
     this.location = event.location ?? undefined;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,10 @@
-import { App } from '@slack/bolt';
-import * as environment from './utils/env';
-import registerListeners from './listeners';
-
+import { App } from "@slack/bolt";
+import * as environment from "./utils/env";
+import registerListeners from "./listeners";
+import { OAuth2Client } from "google-auth-library";
+import { google } from "googleapis";
+const calendar = google.calendar("v3");
+import { config } from "dotenv";
 
 // Initialize app
 const app = new App({
@@ -14,13 +17,37 @@ const app = new App({
 // Register listeners
 registerListeners(app);
 
+// Setup Google OAuth
+async function main(eventId: string, updatedFields: object) {
+  // Set up OAuth2 client
+  const auth = new OAuth2Client({
+    clientId: process.env.GOOGLE_ACCOUNT_CLIENT,
+    clientSecret: process.env.GOOGLE_ACCOUNT_SECRET,
+    redirectUri: "https://developers.google.com/oauthplayground",
+  });
+
+  auth.setCredentials({
+    refresh_token: process.env.GOOGLE_ACCOUNT_TOKEN,
+  });
+
+  const getNextEvents = await calendar.events.list({
+    auth: auth,
+    calendarId: "primary",
+    timeMin: new Date().toISOString(),
+    maxResults: 10,
+    singleEvents: true,
+    orderBy: "startTime",
+  });
+  console.log(getNextEvents.data);
+}
+
 // Start app
 (async () => {
   try {
     await app.start();
     console.log(`⚡️ Bolt app is running!`);
   } catch (error) {
-    console.error('Failed to start the Bolt app', error);
+    console.error("Failed to start the Bolt app", error);
     throw error;
   }
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,14 @@ import { OAuth2Client } from "google-auth-library";
 
 // Set up Google OAuth2 client
 const auth = new OAuth2Client({
-  clientId: process.env.GOOGLE_ACCOUNT_CLIENT,
-  clientSecret: process.env.GOOGLE_ACCOUNT_SECRET,
-  redirectUri: process.env.GOOGLE_ACCOUNT_OAUTH_REDIRECT,
+  clientId: environment.googleAccountClient,
+  clientSecret: environment.googleAccountSecret,
+  redirectUri: environment.googleAccountOauthRedirect,
 });
 
 // Set up OAuth2 credentials
 auth.setCredentials({
-  refresh_token: process.env.GOOGLE_ACCOUNT_TOKEN,
+  refresh_token: environment.googleAccountToken,
 });
 
 // Initialize app
@@ -30,7 +30,7 @@ registerListeners(app);
 (async (): Promise<void> => {
   try {
     await app.start();
-    console.log(`⚡️ Bolt app is running!`);
+    console.log("⚡️ Bolt app is running!");
   } catch (error) {
     console.error("Failed to start the Bolt app", error);
     throw error;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,39 +25,32 @@ const app = new App({
   appToken: environment.slackAppToken,
 });
 
-// Setup Google OAuth
-async function main(): Promise<void> {
-  // Register listeners
-  registerListeners(app);
-
-  // Call the initialize function from googleCalendar.ts
-  const nextEvents = await getEvents(auth);
-
-  // Fetch all channels
-  const channels = await getAllSlackChannels(app);
-
-  // Parse events
-  const eventsToParse = await parseEvents(nextEvents, channels);
-
-  // Parse events by channels
-  const selectedChannels = ["general"];
-  const eventsToParseByChannels = await parseEventsOfChannels(nextEvents, selectedChannels, channels);
-
-  console.log(eventsToParse);
-  console.log(eventsToParseByChannels);
-
-  while (true) {}
-}
+// Register listeners
+registerListeners(app);
 
 // Start app
 (async (): Promise<void> => {
   try {
     await app.start();
     console.log(`⚡️ Bolt app is running!`);
+
+    // Call the initialize function from googleCalendar.ts
+    const nextEvents = await getEvents(auth);
+
+    // Fetch all channels
+    const channels = await getAllSlackChannels(app);
+
+    // Parse events
+    const eventsToParse = await parseEvents(nextEvents, channels);
+
+    // Parse events by channels
+    const selectedChannels = ["general"];
+    const eventsToParseByChannels = await parseEventsOfChannels(nextEvents, selectedChannels, channels);
+
+    console.log(eventsToParse);
+    console.log(eventsToParseByChannels);
   } catch (error) {
     console.error("Failed to start the Bolt app", error);
     throw error;
   }
 })();
-
-main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,12 +26,12 @@ const app = new App({
 });
 
 // Setup Google OAuth
-async function main() {
+async function main(): Promise<void> {
   // Register listeners
   registerListeners(app);
 
   // Call the initialize function from googleCalendar.ts
-  const nextEvents = await getEvents();
+  const nextEvents = await getEvents(auth);
 
   // Fetch all channels
   const channels = await getAllSlackChannels(app);
@@ -50,7 +50,7 @@ async function main() {
 }
 
 // Start app
-(async () => {
+(async (): Promise<void> => {
   try {
     await app.start();
     console.log(`⚡️ Bolt app is running!`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,6 @@ import { App } from "@slack/bolt";
 import * as environment from "./utils/env";
 import registerListeners from "./listeners";
 import { OAuth2Client } from "google-auth-library";
-import { getEvents, parseEvents, parseEventsOfChannels } from "./utils/googleCalendar";
-import { getAllSlackChannels } from "./utils/channels";
 
 // Set up Google OAuth2 client
 const auth = new OAuth2Client({
@@ -33,22 +31,6 @@ registerListeners(app);
   try {
     await app.start();
     console.log(`⚡️ Bolt app is running!`);
-
-    // Call the initialize function from googleCalendar.ts
-    const nextEvents = await getEvents(auth);
-
-    // Fetch all channels
-    const channels = await getAllSlackChannels(app);
-
-    // Parse events
-    const eventsToParse = await parseEvents(nextEvents, channels);
-
-    // Parse events by channels
-    const selectedChannels = ["general"];
-    const eventsToParseByChannels = await parseEventsOfChannels(nextEvents, selectedChannels, channels);
-
-    console.log(eventsToParse);
-    console.log(eventsToParseByChannels);
   } catch (error) {
     console.error("Failed to start the Bolt app", error);
     throw error;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const app = new App({
 registerListeners(app);
 
 // Setup Google OAuth
-async function main(eventId: string, updatedFields: object) {
+async function main() {
   // Set up OAuth2 client
   const auth = new OAuth2Client({
     clientId: process.env.GOOGLE_ACCOUNT_CLIENT,
@@ -39,6 +39,8 @@ async function main(eventId: string, updatedFields: object) {
     orderBy: "startTime",
   });
   console.log(getNextEvents.data);
+
+  while (true) {}
 }
 
 // Start app
@@ -51,3 +53,5 @@ async function main(eventId: string, updatedFields: object) {
     throw error;
   }
 })();
+
+main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { App } from "@slack/bolt";
 import * as environment from "./utils/env";
 import registerListeners from "./listeners";
 import { OAuth2Client } from "google-auth-library";
-import { getEvents, parseEvents } from "./utils/googleCalendar";
+import { getEvents, parseEvents, parseEventsOfChannels } from "./utils/googleCalendar";
 import { getAllSlackChannels } from "./utils/channels";
 
 // Set up Google OAuth2 client
@@ -17,7 +17,7 @@ auth.setCredentials({
   refresh_token: process.env.GOOGLE_ACCOUNT_TOKEN,
 });
 
-// Set up Slack app
+// Initialize app
 const app = new App({
   token: environment.slackBotToken,
   signingSecret: environment.slackSigningSecret,
@@ -39,7 +39,12 @@ async function main() {
   // Parse events
   const eventsToParse = await parseEvents(nextEvents, channels);
 
+  // Parse events by channels
+  const selectedChannels = ["general"];
+  const eventsToParseByChannels = await parseEventsOfChannels(nextEvents, selectedChannels, channels);
+
   console.log(eventsToParse);
+  console.log(eventsToParseByChannels);
 
   while (true) {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import * as environment from "./utils/env";
 import registerListeners from "./listeners";
 import { OAuth2Client } from "google-auth-library";
 import { google } from "googleapis";
+import CalendarEvent from "./classes/CalendarEvent";
+import { getAllSlackChannels } from "./utils/channels";
 const calendar = google.calendar("v3");
 import { config } from "dotenv";
 
@@ -30,6 +32,7 @@ async function main() {
     refresh_token: process.env.GOOGLE_ACCOUNT_TOKEN,
   });
 
+  // Get info of next 10 events
   const getNextEvents = await calendar.events.list({
     auth: auth,
     calendarId: "primary",
@@ -38,7 +41,31 @@ async function main() {
     singleEvents: true,
     orderBy: "startTime",
   });
-  console.log(getNextEvents.data);
+
+  // Events data
+  const nextEvents = getNextEvents.data;
+
+  // Test if event start and end date is defined
+  if (nextEvents.items) {
+    nextEvents.items.forEach((event) => {
+      console.log("Event Start:", JSON.stringify(event.start));
+      console.log("Event End:", JSON.stringify(event.end));
+    });
+  } else {
+    console.log("No events found.");
+  }
+
+  // // Call getAllSlackChannels function
+  // const channelsPromise = getAllSlackChannels(app);
+
+  // // Wait for the channels to be fetched
+  // try {
+  //   const channels = await channelsPromise;
+  //   const calendarEvent1 = new CalendarEvent(nextEvents, channels);
+  //   console.log(calendarEvent1);
+  // } catch (error) {
+  //   console.error("Error fetching Slack channels:", error);
+  // }
 
   while (true) {}
 }

--- a/src/utils/calendarDescription.ts
+++ b/src/utils/calendarDescription.ts
@@ -10,7 +10,7 @@ export type EventMetadata = {
   /**
    * The channel that event reminders should be posted to
    */
-  channel?: SlackChannel;
+  channel: SlackChannel;
   /**
    * The meeting link for the event, if it exists
    */

--- a/src/utils/googleCalendar.ts
+++ b/src/utils/googleCalendar.ts
@@ -2,7 +2,6 @@ import { OAuth2Client } from "google-auth-library";
 import { google, calendar_v3 } from "googleapis";
 import CalendarEvent from "../classes/CalendarEvent";
 import SlackChannel from "../classes/SlackChannel";
-import { filterSlackChannelsFromNames } from "./channels";
 
 /**
  * Fetches all events in the next 24 hours from the Rocketry calendar.
@@ -55,19 +54,11 @@ export async function parseEvents(
  * @returns A promise that resolves to the list of parsed CalendarEvents.
  */
 export async function parseEventsOfChannels(
-  nextEvents: calendar_v3.Schema$Events,
+  calendarEvents: CalendarEvent[],
   channelNames: string[],
-  channels: SlackChannel[],
 ): Promise<CalendarEvent[]> {
-  const filteredChannels = filterSlackChannelsFromNames(channelNames, channels);
-  const events: CalendarEvent[] = [];
-  if (nextEvents.items) {
-    nextEvents.items.forEach((event) => {
-      const calendarEvent = new CalendarEvent(event, filteredChannels);
-      events.push(calendarEvent);
-    });
-  } else {
-    return [];
-  }
-  return events;
+  const filteredEvents = calendarEvents.filter((event) =>
+    channelNames.includes(event.minervaEventMetadata?.channel?.name ?? ""),
+  );
+  return filteredEvents;
 }

--- a/src/utils/googleCalendar.ts
+++ b/src/utils/googleCalendar.ts
@@ -1,7 +1,8 @@
 import { OAuth2Client } from "google-auth-library";
-import { google } from "googleapis";
+import { google, calendar_v3 } from "googleapis";
 import CalendarEvent from "../classes/CalendarEvent";
 import SlackChannel from "../classes/SlackChannel";
+import { filterSlackChannelsFromNames } from "./channels";
 
 const calendar = google.calendar("v3");
 
@@ -35,7 +36,7 @@ export async function getEvents() {
 }
 
 // Parsing all events from all channels in the next 24 hours into a list of CalendarEvents
-export async function parseEvents(nextEvents, channels: SlackChannel[]) {
+export async function parseEvents(nextEvents: calendar_v3.Schema$Events, channels: SlackChannel[]) {
   const events: CalendarEvent[] = [];
   if (nextEvents.items) {
     nextEvents.items.forEach((event) => {
@@ -48,17 +49,21 @@ export async function parseEvents(nextEvents, channels: SlackChannel[]) {
   return events;
 }
 
-// // Parsing all events from specific channels in the next 24 hours into a list of CalendarEvents
-// export async function parseEventsOfChannels(channelNames: string[], channels: SlackChannel[]) {
-//   const filteredChannels = filterSlackChannelsFromNames(channelNames, channels);
-//   const events: CalendarEvent[] = [];
-//   if (nextEvents.items) {
-//     nextEvents.items.forEach((event) => {
-//       const calendarEvent = new CalendarEvent(event, filteredChannels);
-//       events.push(calendarEvent);
-//     });
-//   } else {
-//     return "No events found.";
-//   }
-//   return events;
-// }
+// Parsing all events from specific channels in the next 24 hours into a list of CalendarEvents
+export async function parseEventsOfChannels(
+  nextEvents: calendar_v3.Schema$Events,
+  channelNames: string[],
+  channels: SlackChannel[],
+) {
+  const filteredChannels = filterSlackChannelsFromNames(channelNames, channels);
+  const events: CalendarEvent[] = [];
+  if (nextEvents.items) {
+    nextEvents.items.forEach((event) => {
+      const calendarEvent = new CalendarEvent(event, filteredChannels);
+      events.push(calendarEvent);
+    });
+  } else {
+    return "No events found.";
+  }
+  return events;
+}

--- a/src/utils/googleCalendar.ts
+++ b/src/utils/googleCalendar.ts
@@ -48,9 +48,8 @@ export async function parseEvents(
 
 /**
  * Parses events from specified Slack channels in the next 24 hours into a list of CalendarEvents.
- * @param nextEvents The list of events to be parsed.
+ * @param calendarEvents The list of CalendarEvents to be filtered.
  * @param channelNames The names of SlackChannels to filter and associate with the events.
- * @param channels The array of all SlackChannels available.
  * @returns A promise that resolves to the list of parsed CalendarEvents.
  */
 export async function parseEventsOfChannels(

--- a/src/utils/googleCalendar.ts
+++ b/src/utils/googleCalendar.ts
@@ -1,0 +1,64 @@
+import { OAuth2Client } from "google-auth-library";
+import { google } from "googleapis";
+import CalendarEvent from "../classes/CalendarEvent";
+import SlackChannel from "../classes/SlackChannel";
+
+const calendar = google.calendar("v3");
+
+// Set up Google OAuth2 client
+const auth = new OAuth2Client({
+  clientId: process.env.GOOGLE_ACCOUNT_CLIENT,
+  clientSecret: process.env.GOOGLE_ACCOUNT_SECRET,
+  redirectUri: process.env.GOOGLE_ACCOUNT_OAUTH_REDIRECT,
+});
+
+// Set up OAuth2 credentials
+auth.setCredentials({
+  refresh_token: process.env.GOOGLE_ACCOUNT_TOKEN,
+});
+
+// Function to fetch all events in the next 24 hours
+export async function getEvents() {
+  const currentTime = new Date();
+  const next24Hours = new Date(currentTime.getTime() + 24 * 60 * 60 * 1000);
+
+  const getNextEvents = await calendar.events.list({
+    auth: auth,
+    calendarId: "primary",
+    timeMin: currentTime.toISOString(),
+    timeMax: next24Hours.toISOString(),
+    singleEvents: true,
+    orderBy: "startTime",
+  });
+
+  return getNextEvents.data;
+}
+
+// Parsing all events from all channels in the next 24 hours into a list of CalendarEvents
+export async function parseEvents(nextEvents, channels: SlackChannel[]) {
+  const events: CalendarEvent[] = [];
+  if (nextEvents.items) {
+    nextEvents.items.forEach((event) => {
+      const calendarEvent = new CalendarEvent(event, channels);
+      events.push(calendarEvent);
+    });
+  } else {
+    return "No events found.";
+  }
+  return events;
+}
+
+// // Parsing all events from specific channels in the next 24 hours into a list of CalendarEvents
+// export async function parseEventsOfChannels(channelNames: string[], channels: SlackChannel[]) {
+//   const filteredChannels = filterSlackChannelsFromNames(channelNames, channels);
+//   const events: CalendarEvent[] = [];
+//   if (nextEvents.items) {
+//     nextEvents.items.forEach((event) => {
+//       const calendarEvent = new CalendarEvent(event, filteredChannels);
+//       events.push(calendarEvent);
+//     });
+//   } else {
+//     return "No events found.";
+//   }
+//   return events;
+// }

--- a/src/utils/googleCalendar.ts
+++ b/src/utils/googleCalendar.ts
@@ -4,25 +4,15 @@ import CalendarEvent from "../classes/CalendarEvent";
 import SlackChannel from "../classes/SlackChannel";
 import { filterSlackChannelsFromNames } from "./channels";
 
-const calendar = google.calendar("v3");
-
-// Set up Google OAuth2 client
-const auth = new OAuth2Client({
-  clientId: process.env.GOOGLE_ACCOUNT_CLIENT,
-  clientSecret: process.env.GOOGLE_ACCOUNT_SECRET,
-  redirectUri: process.env.GOOGLE_ACCOUNT_OAUTH_REDIRECT,
-});
-
-// Set up OAuth2 credentials
-auth.setCredentials({
-  refresh_token: process.env.GOOGLE_ACCOUNT_TOKEN,
-});
-
-// Function to fetch all events in the next 24 hours
-export async function getEvents() {
+/**
+ * Fetches all events in the next 24 hours from the Rocketry calendar.
+ * @param auth The OAuth2 client instance for authentication.
+ * @returns A promise that resolves to the list of events.
+ */
+export async function getEvents(auth: OAuth2Client): Promise<calendar_v3.Schema$Events> {
   const currentTime = new Date();
   const next24Hours = new Date(currentTime.getTime() + 24 * 60 * 60 * 1000);
-
+  const calendar = google.calendar("v3");
   const getNextEvents = await calendar.events.list({
     auth: auth,
     calendarId: "primary",
@@ -35,8 +25,16 @@ export async function getEvents() {
   return getNextEvents.data;
 }
 
-// Parsing all events from all channels in the next 24 hours into a list of CalendarEvents
-export async function parseEvents(nextEvents: calendar_v3.Schema$Events, channels: SlackChannel[]) {
+/**
+ * Parses events from all channels in the next 24 hours into a list of CalendarEvents.
+ * @param nextEvents The list of events to be parsed.
+ * @param channels The array of SlackChannels to associate with the events.
+ * @returns A promise that resolves to the list of parsed CalendarEvents.
+ */
+export async function parseEvents(
+  nextEvents: calendar_v3.Schema$Events,
+  channels: SlackChannel[],
+): Promise<CalendarEvent[]> {
   const events: CalendarEvent[] = [];
   if (nextEvents.items) {
     nextEvents.items.forEach((event) => {
@@ -44,17 +42,23 @@ export async function parseEvents(nextEvents: calendar_v3.Schema$Events, channel
       events.push(calendarEvent);
     });
   } else {
-    return "No events found.";
+    return [];
   }
   return events;
 }
 
-// Parsing all events from specific channels in the next 24 hours into a list of CalendarEvents
+/**
+ * Parses events from specified Slack channels in the next 24 hours into a list of CalendarEvents.
+ * @param nextEvents The list of events to be parsed.
+ * @param channelNames The names of SlackChannels to filter and associate with the events.
+ * @param channels The array of all SlackChannels available.
+ * @returns A promise that resolves to the list of parsed CalendarEvents.
+ */
 export async function parseEventsOfChannels(
   nextEvents: calendar_v3.Schema$Events,
   channelNames: string[],
   channels: SlackChannel[],
-) {
+): Promise<CalendarEvent[]> {
   const filteredChannels = filterSlackChannelsFromNames(channelNames, channels);
   const events: CalendarEvent[] = [];
   if (nextEvents.items) {
@@ -63,7 +67,7 @@ export async function parseEventsOfChannels(
       events.push(calendarEvent);
     });
   } else {
-    return "No events found.";
+    return [];
   }
   return events;
 }

--- a/src/utils/googleCalendar.ts
+++ b/src/utils/googleCalendar.ts
@@ -25,39 +25,40 @@ export async function getEvents(auth: OAuth2Client): Promise<calendar_v3.Schema$
 }
 
 /**
- * Parses events from all channels in the next 24 hours into a list of CalendarEvents.
- * @param nextEvents The list of events to be parsed.
+ * Parses events fetched from the Google API into a list of CalendarEvents.
+ * @param events The list of events to be parsed.
  * @param channels The array of SlackChannels to associate with the events.
  * @returns A promise that resolves to the list of parsed CalendarEvents.
  */
 export async function parseEvents(
-  nextEvents: calendar_v3.Schema$Events,
+  events: calendar_v3.Schema$Events,
   channels: SlackChannel[],
 ): Promise<CalendarEvent[]> {
-  const events: CalendarEvent[] = [];
-  if (nextEvents.items) {
-    nextEvents.items.forEach((event) => {
+  const eventsList: CalendarEvent[] = [];
+  if (events.items) {
+    events.items.forEach((event) => {
       const calendarEvent = new CalendarEvent(event, channels);
-      events.push(calendarEvent);
+      eventsList.push(calendarEvent);
     });
   } else {
     return [];
   }
-  return events;
+  return eventsList;
 }
 
 /**
- * Parses events from specified Slack channels in the next 24 hours into a list of CalendarEvents.
+ * Filters CalendarEvents into those only from specified Slack channels.
  * @param calendarEvents The list of CalendarEvents to be filtered.
  * @param channelNames The names of SlackChannels to filter and associate with the events.
- * @returns A promise that resolves to the list of parsed CalendarEvents.
+ * @returns The filtered list of CalendarEvents.
  */
-export async function parseEventsOfChannels(
-  calendarEvents: CalendarEvent[],
-  channelNames: string[],
-): Promise<CalendarEvent[]> {
-  const filteredEvents = calendarEvents.filter((event) =>
-    channelNames.includes(event.minervaEventMetadata?.channel?.name ?? ""),
-  );
+export function parseEventsOfChannels(calendarEvents: CalendarEvent[], channelNames: string[]): CalendarEvent[] {
+  const filteredEvents = calendarEvents.filter((event) => {
+    const metadata = event.minervaEventMetadata;
+    if (metadata && metadata.channel) {
+      return channelNames.includes(metadata.channel.name);
+    }
+    return false;
+  });
   return filteredEvents;
 }


### PR DESCRIPTION
## Description
This PR introduces two new utility functions for retrieving and parsing Google Calendar events into a custom `CalendarEvent` class. The goal is to provide a convenient way to fetch upcoming events within the next 24 hours and filter events by a specific Slack channel.

1. Added a new function `parseEvents`:
    - Parses all events from all channels in the next 24 hours into a list of `CalendarEvent` instances.

2. Added a new function `parseEventsByChannel`:
    - Takes a `channelNames` as an argument and filters upcoming events for that specific channel.

Closes #17 

## Developer Testing
To test the `parseEventsByChannel` function, I created three events, one for the #general channel, one for the #software channel, and one with no description.

parseEvents will produce the following list of CalendarEvents

```
[
  CalendarEvent {
    title: 'General',
    start: 2023-12-27T14:00:00.000Z,
    end: 2023-12-27T15:00:00.000Z,
    location: undefined,
    description: 'this is the event description\n' +
      "Wow, ain't this great.\n" +
      "look at how I'm demonstrating multi-line-ness",
    minervaEventMetadata: {
      channel: [SlackChannel],
      meetingLink: 'https://meet.waterloorocketry.com'
    }
  },
  CalendarEvent {
    title: 'Software',
    start: 2023-12-27T15:00:00.000Z,
    end: 2023-12-27T16:00:00.000Z,
    location: undefined,
    description: 'this is the event description\n' +
      "Wow, ain't this great.\n" +
      "look at how I'm demonstrating multi-line-ness",
    minervaEventMetadata: {
      channel: [SlackChannel],
      meetingLink: 'https://meet.waterloorocketry.com'
    }
  },
  CalendarEvent {
    title: 'No description',
    start: 2023-12-27T16:00:00.000Z,
    end: 2023-12-27T17:00:00.000Z,
    location: undefined
  }
]
```

In the async function, below the `console.log(`⚡️ Bolt app is running!`);` line, add the following lines of code to test:

```
// Call the initialize function from googleCalendar.ts
const nextEvents = await getEvents(auth);

// Fetch all channels
const channels = await getAllSlackChannels(app);

// Parse events
const eventsToParse = await parseEvents(nextEvents, channels);

// Parse events by channels
const selectedChannels = *to be changed for testing*;
const eventsToParseByChannels = await parseEventsOfChannels(eventsToParse, selectedChannels);

console.log(eventsToParseByChannels);
```

And add the imports to top of the file

```
// Add the imports to top of the file
import { getAllSlackChannels } from "./utils/channels";
import { getEvents, parseEvents, parseEventsOfChannels } from "./utils/googleCalendar";
```

Test 1: Existing channel with events under it (const selectedChannels = ["software"])
Result:
```
[
  CalendarEvent {
    title: 'Software',
    start: 2023-12-27T15:00:00.000Z,
    end: 2023-12-27T16:00:00.000Z,
    location: undefined,
    description: 'this is the event description\n' +
      "Wow, ain't this great.\n" +
      "look at how I'm demonstrating multi-line-ness",
    minervaEventMetadata: {
      channel: [SlackChannel],
      meetingLink: 'https://meet.waterloorocketry.com'
    }
  }
]
```

Test 2: Exisiting channel but no events under it (const selectedChannels = ["media"])
Result:
```
[]
```

Test 3: Non-existent channel (const selectedChannels = ["fake"])
Result:
```
[]
```

## Reviewer Testing



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/57)
<!-- Reviewable:end -->
