### PR TITLE
Pass the Slack Web API into functions instead of the entire Bolt App

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ const app = new App({
 registerListeners(app);
 
 // Schedule tasks
-scheduleTasks(app, auth);
+scheduleTasks(app.client, auth);
 
 // Start app
 (async (): Promise<void> => {

--- a/src/scheduled/checkForEvents.ts
+++ b/src/scheduled/checkForEvents.ts
@@ -1,15 +1,15 @@
-import { App } from "@slack/bolt";
+import { WebClient } from "@slack/web-api";
 import { OAuth2Client } from "google-auth-library";
 import { getEvents, parseEvents } from "../utils/googleCalendar";
 import { getAllSlackChannels } from "../utils/channels";
 import { remindUpcomingEvents } from "../utils/eventReminders";
 
-const checkForEvents = async (app: App, auth: OAuth2Client): Promise<void> => {
-  const slackChannels = await getAllSlackChannels(app);
+const checkForEvents = async (client: WebClient, auth: OAuth2Client): Promise<void> => {
+  const slackChannels = await getAllSlackChannels(client);
   const fetchedEvents = await getEvents(auth);
   const events = await parseEvents(fetchedEvents, slackChannels);
 
-  remindUpcomingEvents(events, app);
+  remindUpcomingEvents(events, client);
 };
 
 export default checkForEvents;

--- a/src/scheduled/index.ts
+++ b/src/scheduled/index.ts
@@ -1,11 +1,12 @@
-import schedule from "node-schedule";
-import checkForEvents from "./checkForEvents";
-import { App } from "@slack/bolt";
+import { WebClient } from "@slack/web-api";
 import { OAuth2Client } from "google-auth-library";
 
-const scheduleTasks = (app: App, googleAuth: OAuth2Client): void => {
+import schedule from "node-schedule";
+import checkForEvents from "./checkForEvents";
+
+const scheduleTasks = (client: WebClient, googleAuth: OAuth2Client): void => {
   // Runs every five minutes
-  schedule.scheduleJob("*/5 * * *", () => checkForEvents(app, googleAuth));
+  schedule.scheduleJob("*/5 * * *", () => checkForEvents(client, googleAuth));
 };
 
 export default scheduleTasks;

--- a/src/utils/channels.ts
+++ b/src/utils/channels.ts
@@ -1,4 +1,4 @@
-import { App } from "@slack/bolt";
+import { WebClient } from "@slack/web-api";
 import SlackChannel from "../classes/SlackChannel";
 import { defaultSlackChannels } from "../common/constants";
 
@@ -62,12 +62,12 @@ export function filterDefaultSlackChannels(channels: SlackChannel[]): SlackChann
 
 /**
  * Retrieves all Slack channels using the Slack API.
- * @param app - The Slack Bolt app instance.
+ * @param client Slack Web API client
  * @returns A promise that resolves to an array of Slack channels.
  */
-export async function getAllSlackChannels(app: App): Promise<SlackChannel[]> {
+export async function getAllSlackChannels(client: WebClient): Promise<SlackChannel[]> {
   // Excludes archived channels and has a maximum limit of 1000 channels.
-  const channels = await app.client.conversations.list({
+  const channels = await client.conversations.list({
     types: "public_channel",
     exclude_archived: true,
     limit: 1000, // This is the max limit

--- a/src/utils/eventReminders.ts
+++ b/src/utils/eventReminders.ts
@@ -1,4 +1,4 @@
-import { App } from "@slack/bolt";
+import { WebClient } from "@slack/web-api";
 
 import CalendarEvent from "../classes/CalendarEvent";
 import { postMessage } from "./slack";
@@ -51,10 +51,10 @@ export function getEventReminderType(event: CalendarEvent): EventReminderType | 
 /**
  * Posts a reminder for the given event to the channel it is associated with
  * @param event The event to post a reminder for
- * @param app The Bolt App
+ * @param client Slack Web API client
  * @todo add support for #default as a channel
  */
-export function remindUpcomingEvent(event: CalendarEvent, app: App): void {
+export function remindUpcomingEvent(event: CalendarEvent, client: WebClient): void {
   // If the event does not have event metadata, then minerva ignores it
   if (!event.minervaEventMetadata) {
     return;
@@ -70,17 +70,17 @@ export function remindUpcomingEvent(event: CalendarEvent, app: App): void {
   console.log(
     `Sending reminder for event ${event.title} at ${event.start} to #${event.minervaEventMetadata.channel.name}.`,
   );
-  postMessage(app, event.minervaEventMetadata.channel, reminderText);
+  postMessage(client, event.minervaEventMetadata.channel, reminderText);
 }
 
 /**
  * Posts reminders for the given events to the channels they are associated with
  * @param events The events to post reminders for
- * @param app The Bolt App
+ * @param client Slack Web API client
  */
-export function remindUpcomingEvents(events: CalendarEvent[], app: App): void {
+export function remindUpcomingEvents(events: CalendarEvent[], client: WebClient): void {
   events.forEach((event) => {
-    remindUpcomingEvent(event, app);
+    remindUpcomingEvent(event, client);
   });
 }
 

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -1,17 +1,17 @@
-import { App } from "@slack/bolt";
+import { WebClient } from "@slack/web-api";
 
 import SlackChannel from "../classes/SlackChannel";
 
 /**
  * Posts a message to a Slack channel
- * @param app The Bolt App
+ * @param client Slack Web API client
  * @param channel The Slack channel to post the message to
  * @param text The text of the message to post
  * @todo Add support for #default as a channel
  */
-export function postMessage(app: App, channel: SlackChannel, text: string): void {
+export function postMessage(client: WebClient, channel: SlackChannel, text: string): void {
   try {
-    app.client.chat.postMessage({
+    client.chat.postMessage({
       channel: channel.id,
       text: text,
     });


### PR DESCRIPTION
## Description
<!-- Add background/context for the PR (why are we making these changes?) and a description of the changes that this makes. -->
While @shirleyfyx and I were working through figuring out how to call functions that interact with the Slack API from within an event callback we realized that requiring `app` to be passed into those functions does not work well as these callback would not have easy access to the. They do, however, have access to the Slack Web API client as a parameter(`app.client`). Given that we're calling `app.client...` for all our API interactions anyway, we can make this change relatively easily.

This PR changes all instances of us passing the Bolt App into functions to just passing the Slack API client. This change does not include registering listeners, as that still requires use of the Bolt app.

## Developer Testing
<!-- Outline steps that you have taken to test your newly implemented functionality. e.g. implementing new unit tests, steps taken for manual testing, etc. -->
Testing done:
- Ran unit tests

## Reviewer Testing
<!-- Provide some steps that reviewers can take to test your functionality (or just view the new feature) on their side.  -->
<!-- Note that much of minerva's functionality needs to be tested on the Dev Slack, so you should write these steps accordingly -->

- None required, this is a simple refactor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/61)
<!-- Reviewable:end -->
