### PR TITLE
Implement Better Logging

### DIFF
--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -29,7 +29,7 @@ jobs:
           echo GOOGLE_ACCOUNT_CLIENT=${{ secrets.GOOGLE_ACCOUNT_CLIENT }} >> .env
           echo GOOGLE_ACCOUNT_SECRET=${{ secrets.GOOGLE_ACCOUNT_SECRET }} >> .env
           echo GOOGLE_ACCOUNT_TOKEN=${{ secrets.GOOGLE_ACCOUNT_TOKEN }} >> .env
-          echo GOOGLE_ACCOUNT_OAUTH_REDIRECT=${{ secrets.GOOGLE_ACCOUNT_OAUTH_REDIRECT }} >> .env
+          echo GOOGLE_ACCOUNT_OAUTH_REDIRECT=${{ vars.GOOGLE_ACCOUNT_OAUTH_REDIRECT }} >> .env
           echo SLACK_APP_TOKEN=${{ secrets.SLACK_APP_TOKEN }} >> .env
           echo SLACK_OAUTH_TOKEN=${{ secrets.SLACK_OAUTH_TOKEN }} >> .env
           echo SLACK_SIGNING_SECRET=${{ secrets.SLACK_SIGNING_SECRET }} >> .env

--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -33,6 +33,7 @@ jobs:
           echo SLACK_APP_TOKEN=${{ secrets.SLACK_APP_TOKEN }} >> .env
           echo SLACK_OAUTH_TOKEN=${{ secrets.SLACK_OAUTH_TOKEN }} >> .env
           echo SLACK_SIGNING_SECRET=${{ secrets.SLACK_SIGNING_SECRET }} >> .env
+          echo DEPLOY_COMMIT_SHA=${{ github.sha }} >> .env
       - name: Move files to dist
         run: |
           mv .env ./dist/
@@ -54,7 +55,7 @@ jobs:
           key: ${{ secrets.REMOTE_KEY }}
           script: |
             cd ~/minerva-dev
-      
+
             echo "Starting the application with PM2."
             pm2 start ecosystem.config.js 
 
@@ -70,4 +71,3 @@ jobs:
               echo "PM2 application has failed to start."
               exit 1
             fi
-            

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -2,7 +2,7 @@ module.exports = {
   apps: [
     {
       name: "minerva-dev",
-      script: "node ./bundle.js 2>&1 | rtail --id minerva-dev",
+      script: "node ./bundle.js",
       time: true,
       instances: 1,
       autorestart: true,

--- a/src/classes/CalendarEvent.ts
+++ b/src/classes/CalendarEvent.ts
@@ -41,15 +41,24 @@ export default class CalendarEvent {
    * @param event The google calendar event to parse
    * @param workspaceChannels The list of slack channels in the workspace. Used to create SlackChannel objects from the channel names in the event description
    * @returns The parsed CalendarEvent object
+   * @throws Error if the event summary, start time, end time, or URL is undefined
    */
   static fromGoogleCalendarEvent(event: calendar_v3.Schema$Event, workspaceChannels: SlackChannel[]): CalendarEvent {
-    if (event.summary == undefined) throw new Error("Event summary is undefined");
+    if (event.summary == undefined) {
+      throw new Error("Event summary is undefined");
+    }
     const title = event.summary;
-    if (event.start?.dateTime == undefined) throw new Error("Event start is undefined");
+    if (event.start?.dateTime == undefined) {
+      throw new Error(`Event start is undefined for event ${event.summary}`);
+    }
     const start = new Date(event.start.dateTime);
-    if (event.end?.dateTime == undefined) throw new Error("Event end is undefined");
+    if (event.end?.dateTime == undefined) {
+      throw new Error(`Event end is undefined for event ${event.summary}`);
+    }
     const end = new Date(event.end.dateTime);
-    if (event.htmlLink == undefined) throw new Error("Event URL is undefined");
+    if (event.htmlLink == undefined) {
+      throw new Error(`Event URL is undefined for event ${event.summary}`);
+    }
     const url = event.htmlLink;
 
     const parsedEvent = new CalendarEvent(title, start, end, url);
@@ -58,10 +67,13 @@ export default class CalendarEvent {
     parsedEvent.url = event.htmlLink ?? undefined;
 
     if (event?.description != undefined) {
-      const { description, minervaEventMetadata } = parseDescription(event.description, workspaceChannels);
-
-      parsedEvent.description = description;
-      parsedEvent.minervaEventMetadata = minervaEventMetadata;
+      try {
+        const { description, minervaEventMetadata } = parseDescription(event.description, workspaceChannels);
+        parsedEvent.minervaEventMetadata = minervaEventMetadata;
+        parsedEvent.description = description;
+      } catch (error) {
+        throw new Error(`Failed to parse event description: ${String(error)}`);
+      }
     }
 
     return parsedEvent;

--- a/src/classes/CalendarEvent.ts
+++ b/src/classes/CalendarEvent.ts
@@ -72,7 +72,10 @@ export default class CalendarEvent {
         parsedEvent.minervaEventMetadata = minervaEventMetadata;
         parsedEvent.description = description;
       } catch (error) {
-        throw new Error(`Failed to parse event description`, { cause: error });
+        if (error instanceof Error) {
+          throw new Error(`Failed to parse event description for event ${event.summary} with error: ${error.message}`);
+        }
+        throw new Error(`Failed to parse event description for event ${event.summary}: ${error}`);
       }
     }
 

--- a/src/classes/CalendarEvent.ts
+++ b/src/classes/CalendarEvent.ts
@@ -49,15 +49,15 @@ export default class CalendarEvent {
     }
     const title = event.summary;
     if (event.start?.dateTime == undefined) {
-      throw new Error(`Event start is undefined for event ${event.summary}`);
+      throw new Error(`Event start is undefined for event "${event.summary}"`);
     }
     const start = new Date(event.start.dateTime);
     if (event.end?.dateTime == undefined) {
-      throw new Error(`Event end is undefined for event ${event.summary}`);
+      throw new Error(`Event end is undefined for event "${event.summary}"`);
     }
     const end = new Date(event.end.dateTime);
     if (event.htmlLink == undefined) {
-      throw new Error(`Event URL is undefined for event ${event.summary}`);
+      throw new Error(`Event URL is undefined for event "${event.summary}"`);
     }
     const url = event.htmlLink;
 
@@ -73,7 +73,9 @@ export default class CalendarEvent {
         parsedEvent.description = description;
       } catch (error) {
         if (error instanceof Error) {
-          throw new Error(`Failed to parse event description for event ${event.summary} with error: ${error.message}`);
+          throw new Error(
+            `Failed to parse event description for event "${event.summary}" with error: ${error.message}`,
+          );
         }
         throw new Error(`Failed to parse event description for event ${event.summary}: ${error}`);
       }

--- a/src/classes/CalendarEvent.ts
+++ b/src/classes/CalendarEvent.ts
@@ -72,7 +72,7 @@ export default class CalendarEvent {
         parsedEvent.minervaEventMetadata = minervaEventMetadata;
         parsedEvent.description = description;
       } catch (error) {
-        throw new Error(`Failed to parse event description: ${String(error)}`);
+        throw new Error(`Failed to parse event description`, { cause: error });
       }
     }
 

--- a/src/classes/SlackLogger.ts
+++ b/src/classes/SlackLogger.ts
@@ -125,10 +125,6 @@ export class SlackLogger {
    * @returns The formatted code block content
    */
   private formatcodeBlockContent(codeBlockContent: unknown): string {
-    if (codeBlockContent instanceof Error) {
-      return `\`\`\`${codeBlockContent.message}\`\`\``;
-    } else {
-      return `\`\`\`${codeBlockContent}\`\`\``;
-    }
+    return `\`\`\`${codeBlockContent}\`\`\``;
   }
 }

--- a/src/classes/SlackLogger.ts
+++ b/src/classes/SlackLogger.ts
@@ -49,13 +49,13 @@ export class SlackLogger {
    * Log a message to the minerva logging channel in Slack
    * @param level The level of the log
    * @param message The message to log
-   * @param codeBlockContent The content of the code block to log after the message, if any. To be used for logging errors
+   * @param codeBlockContent The content of the code block to log after the message, if any.
    * @param logToConsole Whether to log the message to the console in addition to Slack
    */
   private async log(
     level: LogLevel,
     message: string,
-    codeBlockContent: string = "",
+    codeBlockContent: unknown = "",
     logToConsole = true,
   ): Promise<void> {
     const formattedMessage = this.formatMessage(level, message);
@@ -85,7 +85,7 @@ export class SlackLogger {
    * @param codeBlockContent The content of the code block to log after the message, if any.
    * @param logToConsole Whether to log the message to the console in addition to Slack
    */
-  async info(message: string, codeBlockContent: string = "", logToConsole = true): Promise<void> {
+  async info(message: string, codeBlockContent: unknown = "", logToConsole = true): Promise<void> {
     await this.log(LogLevel.INFO, message, codeBlockContent, logToConsole);
   }
   /**
@@ -94,7 +94,7 @@ export class SlackLogger {
    * @param codeBlockContent The content of the code block to log after the message, if any.
    * @param logToConsole Whether to log the message to the console in addition to Slack
    */
-  async warning(message: string, codeBlockContent: string = "", logToConsole = true): Promise<void> {
+  async warning(message: string, codeBlockContent: unknown = "", logToConsole = true): Promise<void> {
     await this.log(LogLevel.WARNING, message, codeBlockContent, logToConsole);
   }
 
@@ -104,7 +104,7 @@ export class SlackLogger {
    * @param codeBlockContent The content of the code block to log after the message, if any. Can be used to log the error content
    * @param logToConsole Whether to log the message to the console in addition to Slack
    */
-  async error(message: string, codeBlockContent: string = "", logToConsole = true): Promise<void> {
+  async error(message: string, codeBlockContent: unknown = "", logToConsole = true): Promise<void> {
     await this.log(LogLevel.ERROR, message, codeBlockContent, logToConsole);
   }
 
@@ -124,7 +124,11 @@ export class SlackLogger {
    * @param codeBlockContent The content of the code block
    * @returns The formatted code block content
    */
-  private formatcodeBlockContent(codeBlockContent: string): string {
-    return `\`\`\`${codeBlockContent}\`\`\``;
+  private formatcodeBlockContent(codeBlockContent: unknown): string {
+    if (codeBlockContent instanceof Error) {
+      return `\`\`\`${codeBlockContent.message}\`\`\``;
+    } else {
+      return `\`\`\`${codeBlockContent}\`\`\``;
+    }
   }
 }

--- a/src/classes/SlackLogger.ts
+++ b/src/classes/SlackLogger.ts
@@ -1,0 +1,64 @@
+import { WebClient } from "@slack/web-api";
+import { postMessage } from "../utils/slack";
+import * as environment from "../utils/env";
+import { loggingChannel } from "../common/constants";
+import { App } from "@slack/bolt";
+
+export enum LogLevel {
+  INFO = "INFO",
+  WARNING = "WARN",
+  ERROR = "ERROR",
+}
+
+export class SlackLogger {
+  private static instance: SlackLogger;
+  slackClient: WebClient;
+
+  private constructor(slackClient: WebClient) {
+    this.slackClient = slackClient;
+  }
+
+  static getInstance(): SlackLogger {
+    if (!SlackLogger.instance) {
+      const app = new App({
+        token: environment.slackBotToken,
+        signingSecret: environment.slackSigningSecret,
+        socketMode: true,
+        appToken: environment.slackAppToken,
+      });
+      SlackLogger.instance = new SlackLogger(app.client);
+    }
+    return SlackLogger.instance;
+  }
+
+  private async log(level: LogLevel, message: string, logToConsole = true): Promise<void> {
+    const formattedMessage = this.formatMessage(level, message);
+
+    if (logToConsole) {
+      if (level === LogLevel.ERROR) {
+        console.error(formattedMessage);
+      } else {
+        console.log(formattedMessage);
+      }
+    }
+
+    await postMessage(this.slackClient, loggingChannel, formattedMessage);
+  }
+
+  async info(message: string, logToConsole = true): Promise<void> {
+    await this.log(LogLevel.INFO, message, logToConsole);
+  }
+
+  async warning(message: string, logToConsole = true): Promise<void> {
+    await this.log(LogLevel.WARNING, message, logToConsole);
+  }
+
+  async error(message: string, logToConsole = true): Promise<void> {
+    await this.log(LogLevel.ERROR, message, logToConsole);
+  }
+
+  private formatMessage(level: LogLevel, message: string): string {
+    const timeStamp = new Date().toISOString();
+    return `[${timeStamp}] [${level}] ${message}`;
+  }
+}

--- a/src/classes/SlackLogger.ts
+++ b/src/classes/SlackLogger.ts
@@ -73,7 +73,7 @@ export class SlackLogger {
     let formattedSlackMessage = formattedMessage;
 
     if (codeBlockContent) {
-      formattedSlackMessage += "\n" + this.formatcodeBlockContent(codeBlockContent);
+      formattedSlackMessage += "\n" + SlackLogger.formatCodeBlockContent(codeBlockContent);
     }
 
     await postMessage(this.slackClient, loggingChannel, formattedSlackMessage);
@@ -124,7 +124,7 @@ export class SlackLogger {
    * @param codeBlockContent The content of the code block
    * @returns The formatted code block content
    */
-  private formatcodeBlockContent(codeBlockContent: unknown): string {
+  private static formatCodeBlockContent(codeBlockContent: unknown): string {
     return `\`\`\`${codeBlockContent}\`\`\``;
   }
 }

--- a/src/classes/SlackLogger.ts
+++ b/src/classes/SlackLogger.ts
@@ -31,34 +31,51 @@ export class SlackLogger {
     return SlackLogger.instance;
   }
 
-  private async log(level: LogLevel, message: string, logToConsole = true): Promise<void> {
+  private async log(
+    level: LogLevel,
+    message: string,
+    codeBlockContent: string = "",
+    logToConsole = true,
+  ): Promise<void> {
     const formattedMessage = this.formatMessage(level, message);
 
     if (logToConsole) {
       if (level === LogLevel.ERROR) {
         console.error(formattedMessage);
+        console.error(codeBlockContent);
       } else {
         console.log(formattedMessage);
+        console.log(codeBlockContent);
       }
     }
 
-    await postMessage(this.slackClient, loggingChannel, formattedMessage);
+    let formattedSlackMessage = formattedMessage;
+
+    if (codeBlockContent) {
+      formattedSlackMessage += "\n" + this.formatcodeBlockContent(codeBlockContent);
+    }
+
+    await postMessage(this.slackClient, loggingChannel, formattedSlackMessage);
   }
 
-  async info(message: string, logToConsole = true): Promise<void> {
-    await this.log(LogLevel.INFO, message, logToConsole);
+  async info(message: string, codeBlockContent: string = "", logToConsole = true): Promise<void> {
+    await this.log(LogLevel.INFO, message, codeBlockContent, logToConsole);
   }
 
-  async warning(message: string, logToConsole = true): Promise<void> {
-    await this.log(LogLevel.WARNING, message, logToConsole);
+  async warning(message: string, codeBlockContent: string = "", logToConsole = true): Promise<void> {
+    await this.log(LogLevel.WARNING, message, codeBlockContent, logToConsole);
   }
 
-  async error(message: string, logToConsole = true): Promise<void> {
-    await this.log(LogLevel.ERROR, message, logToConsole);
+  async error(message: string, codeBlockContent: string = "", logToConsole = true): Promise<void> {
+    await this.log(LogLevel.ERROR, message, codeBlockContent, logToConsole);
   }
 
   private formatMessage(level: LogLevel, message: string): string {
     const timeStamp = new Date().toISOString();
     return `[${timeStamp}] [${level}] ${message}`;
+  }
+
+  private formatcodeBlockContent(codeBlockContent: string): string {
+    return `\`\`\`${codeBlockContent}\`\`\``;
   }
 }

--- a/src/classes/SlackLogger.ts
+++ b/src/classes/SlackLogger.ts
@@ -4,20 +4,34 @@ import * as environment from "../utils/env";
 import { loggingChannel } from "../common/constants";
 import { App } from "@slack/bolt";
 
+/**
+ * The levels of logging that can be used
+ */
 export enum LogLevel {
   INFO = "INFO",
   WARNING = "WARN",
   ERROR = "ERROR",
 }
 
+/**
+ * A class to handle logging to Slack
+ */
 export class SlackLogger {
   private static instance: SlackLogger;
   slackClient: WebClient;
 
+  /**
+   * Singleton constructor for SlackLogger
+   * @param slackClient The Slack Web API client to use for logging
+   */
   private constructor(slackClient: WebClient) {
     this.slackClient = slackClient;
   }
 
+  /**
+   * Get the singleton instance of SlackLogger
+   * @returns The singleton instance of SlackLogger
+   */
   static getInstance(): SlackLogger {
     if (!SlackLogger.instance) {
       const app = new App({
@@ -31,6 +45,13 @@ export class SlackLogger {
     return SlackLogger.instance;
   }
 
+  /**
+   * Log a message to the minerva logging channel in Slack
+   * @param level The level of the log
+   * @param message The message to log
+   * @param codeBlockContent The content of the code block to log after the message, if any. To be used for logging errors
+   * @param logToConsole Whether to log the message to the console in addition to Slack
+   */
   private async log(
     level: LogLevel,
     message: string,
@@ -58,23 +79,51 @@ export class SlackLogger {
     await postMessage(this.slackClient, loggingChannel, formattedSlackMessage);
   }
 
+  /**
+   * Log an info message to Slack
+   * @param message The message to log
+   * @param codeBlockContent The content of the code block to log after the message, if any.
+   * @param logToConsole Whether to log the message to the console in addition to Slack
+   */
   async info(message: string, codeBlockContent: string = "", logToConsole = true): Promise<void> {
     await this.log(LogLevel.INFO, message, codeBlockContent, logToConsole);
   }
-
+  /**
+   * Log a warning message to Slack
+   * @param message The message to log
+   * @param codeBlockContent The content of the code block to log after the message, if any.
+   * @param logToConsole Whether to log the message to the console in addition to Slack
+   */
   async warning(message: string, codeBlockContent: string = "", logToConsole = true): Promise<void> {
     await this.log(LogLevel.WARNING, message, codeBlockContent, logToConsole);
   }
 
+  /**
+   * Log an error message to Slack
+   * @param message The message to log
+   * @param codeBlockContent The content of the code block to log after the message, if any. Can be used to log the error content
+   * @param logToConsole Whether to log the message to the console in addition to Slack
+   */
   async error(message: string, codeBlockContent: string = "", logToConsole = true): Promise<void> {
     await this.log(LogLevel.ERROR, message, codeBlockContent, logToConsole);
   }
 
+  /**
+   * Formats the message into a log line
+   * @param level The message level
+   * @param message The message to log
+   * @returns The formatted log line
+   */
   private formatMessage(level: LogLevel, message: string): string {
     const timeStamp = new Date().toISOString();
     return `[${timeStamp}] [${level}] ${message}`;
   }
 
+  /**
+   * Formats code block content for Slack
+   * @param codeBlockContent The content of the code block
+   * @returns The formatted code block content
+   */
   private formatcodeBlockContent(codeBlockContent: string): string {
     return `\`\`\`${codeBlockContent}\`\`\``;
   }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,4 +1,5 @@
 import { environment } from "../utils/env";
+import SlackChannel from "../classes/SlackChannel";
 
 /**
  * The "default" slack channels for use in sending DM reminders to single-channel guests
@@ -19,3 +20,8 @@ export const defaultSlackChannels =
         "software",
       ]
     : ["general", "random", "software", "test", "propulsion"]; // default channels for development
+
+export const loggingChannel =
+  environment == "production"
+    ? new SlackChannel("minerva-log", "C016AAGP83F")
+    : new SlackChannel("minerva-log", "C015FSK7FQE");

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ scheduleTasks(app.client, auth);
   } catch (error) {
     SlackLogger.getInstance().error(
       `Minerva has failed to start. Deployment commit hash: \`${environment.deploymentCommitHash}\``,
-      String(error),
+      error,
     );
   }
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,8 @@ scheduleTasks(app.client, auth);
     SlackLogger.getInstance().info(`Minerva has started. Deployment commit hash: ${environment.deploymentCommitHash}`);
   } catch (error) {
     SlackLogger.getInstance().error(
-      `Minerva has failed to start. Deployment commit hash: ${environment.deploymentCommitHash}:`,
+      `Minerva has failed to start. Deployment commit hash: \`${environment.deploymentCommitHash}\``,
       String(error),
     );
-    throw error;
   }
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,9 +36,12 @@ scheduleTasks(app.client, auth);
 (async (): Promise<void> => {
   try {
     await app.start();
-    SlackLogger.getInstance().info("Minerva has started.");
+    SlackLogger.getInstance().info(`Minerva has started. Deployment commit hash: ${environment.deploymentCommitHash}`);
   } catch (error) {
-    SlackLogger.getInstance().error("Minerva has failed to start.");
+    SlackLogger.getInstance().error(
+      `Minerva has failed to start. Deployment commit hash: ${environment.deploymentCommitHash}:`,
+      String(error),
+    );
     throw error;
   }
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,9 @@ scheduleTasks(app.client, auth);
 (async (): Promise<void> => {
   try {
     await app.start();
-    SlackLogger.getInstance().info(`Minerva has started. Deployment commit hash: ${environment.deploymentCommitHash}`);
+    SlackLogger.getInstance().info(
+      `Minerva has started. Deployment commit hash: \`${environment.deploymentCommitHash}\``,
+    );
   } catch (error) {
     SlackLogger.getInstance().error(
       `Minerva has failed to start. Deployment commit hash: \`${environment.deploymentCommitHash}\``,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import registerListeners from "./listeners";
 import { OAuth2Client } from "google-auth-library";
 import scheduleTasks from "./scheduled";
 
+import { SlackLogger } from "./classes/SlackLogger";
+
 // Set up Google OAuth2 client
 const auth = new OAuth2Client({
   clientId: environment.googleAccountClient,
@@ -34,9 +36,9 @@ scheduleTasks(app.client, auth);
 (async (): Promise<void> => {
   try {
     await app.start();
-    console.log("⚡️ Bolt app is running!");
+    SlackLogger.getInstance().info("Minerva has started.");
   } catch (error) {
-    console.error("Failed to start the Bolt app", error);
+    SlackLogger.getInstance().error("Minerva has failed to start.");
     throw error;
   }
 })();

--- a/src/listeners/commands/helpCommand.ts
+++ b/src/listeners/commands/helpCommand.ts
@@ -1,10 +1,12 @@
 import { slackBotToken } from "../../utils/env";
 import { Middleware, SlackCommandMiddlewareArgs } from "@slack/bolt";
+import { logCommandUsed } from "../../utils/logging";
 
 const message = `For more information, check out <https://github.com/waterloo-rocketry/minerva-rewrite/blob/main/README.md|minerva's README>.`;
 
 export const helpCommandHandler: Middleware<SlackCommandMiddlewareArgs> = async ({ command, ack, client }) => {
   await ack();
+  await logCommandUsed(command);
 
   await client.chat.postEphemeral({
     token: slackBotToken,

--- a/src/listeners/commands/helpCommand.ts
+++ b/src/listeners/commands/helpCommand.ts
@@ -1,7 +1,6 @@
 import { Middleware, SlackCommandMiddlewareArgs } from "@slack/bolt";
 import { logCommandUsed } from "../../utils/logging";
 import { postEphemeralMessage } from "../../utils/slack";
-import { SlackLogger } from "../../classes/SlackLogger";
 
 const message = `For more information, check out <https://github.com/waterloo-rocketry/minerva-rewrite/blob/main/README.md|minerva's README>.`;
 
@@ -9,14 +8,5 @@ export const helpCommandHandler: Middleware<SlackCommandMiddlewareArgs> = async 
   await ack();
   await logCommandUsed(command);
 
-  try {
-    await postEphemeralMessage(client, command.channel_id, command.user_id, message);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    throw new Error("This is a test error");
-  } catch (error) {
-    SlackLogger.getInstance().error(
-      `Failed to post ephemeral message to user \`${command.user_id}\` with error:`,
-      error,
-    );
-  }
+  await postEphemeralMessage(client, command.channel_id, command.user_id, message);
 };

--- a/src/listeners/commands/helpCommand.ts
+++ b/src/listeners/commands/helpCommand.ts
@@ -1,6 +1,7 @@
-import { slackBotToken } from "../../utils/env";
 import { Middleware, SlackCommandMiddlewareArgs } from "@slack/bolt";
 import { logCommandUsed } from "../../utils/logging";
+import { postEphemeralMessage } from "../../utils/slack";
+import { SlackLogger } from "../../classes/SlackLogger";
 
 const message = `For more information, check out <https://github.com/waterloo-rocketry/minerva-rewrite/blob/main/README.md|minerva's README>.`;
 
@@ -8,10 +9,14 @@ export const helpCommandHandler: Middleware<SlackCommandMiddlewareArgs> = async 
   await ack();
   await logCommandUsed(command);
 
-  await client.chat.postEphemeral({
-    token: slackBotToken,
-    channel: command.channel_id,
-    user: command.user_id,
-    text: message,
-  });
+  try {
+    await postEphemeralMessage(client, command.channel_id, command.user_id, message);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    throw new Error("This is a test error");
+  } catch (error) {
+    SlackLogger.getInstance().error(
+      `Failed to post ephemeral message to user \`${command.user_id}\` with error:`,
+      error,
+    );
+  }
 };

--- a/src/utils/calendarDescription.ts
+++ b/src/utils/calendarDescription.ts
@@ -55,6 +55,7 @@ export function parseDescriptionFromHtml(description: string): string {
   // TODO parse description as markdown potentially - would allow for slack to have more formatting
   const plainDescription = convert(description, {
     wordwrap: false,
+    preserveNewlines: true,
     selectors: [{ selector: "a", options: { ignoreHref: true } }],
   });
 

--- a/src/utils/calendarDescription.ts
+++ b/src/utils/calendarDescription.ts
@@ -85,7 +85,7 @@ export function parseDescription(
   }
 
   const channel = filterSlackChannelFromName(channelName, workspaceChannels);
-  if (channel == undefined) throw new Error(`channel ${channelName} not found`);
+  if (channel == undefined) throw new Error(`channel "${channelName}" not found`);
 
   const minervaEventMetadata = {
     channel,

--- a/src/utils/calendarDescription.ts
+++ b/src/utils/calendarDescription.ts
@@ -66,6 +66,7 @@ export function parseDescriptionFromHtml(description: string): string {
  * @param description The description of the event to parse
  * @param workspaceChannels The Slack channels in the workspace
  * @returns The parsed description and the metadata of the event that minerva uses
+ * @throws Error if the channel name is not specified or if the channel is not found
  */
 export function parseDescription(
   description: string,

--- a/src/utils/channels.ts
+++ b/src/utils/channels.ts
@@ -2,6 +2,7 @@ import { WebClient } from "@slack/web-api";
 import SlackChannel from "../classes/SlackChannel";
 import ObjectSet from "../classes/ObjectSet";
 import { defaultSlackChannels } from "../common/constants";
+import { SlackLogger } from "../classes/SlackLogger";
 
 /**
  * Filters a Slack channel from an array of channels based on its name.
@@ -35,13 +36,13 @@ export function filterSlackChannelsFromNames(names: string[], channels: SlackCha
       const channel = channels.find((channel) => channel.name === name);
       // If a channel with a given name is not found, it logs an error and continues to the next name.
       if (channel == undefined) {
-        console.error(`could not find channel with name ${name}`);
+        SlackLogger.getInstance().warning(`could not find channel with name ${name} when filtering channels`);
         continue;
       }
 
       // If a channel has an undefined name or id, it logs an error and continues to the next channel.
       if (channel.name == undefined || channel.id == undefined) {
-        console.error(`channel with name ${name} has undefined name or id. This should not happen.`);
+        SlackLogger.getInstance().error(`channel with name ${name} has undefined name or id. This should not happen.`);
         continue;
       }
 
@@ -78,7 +79,7 @@ export async function getAllSlackChannels(client: WebClient): Promise<SlackChann
 
   for (const channel of channels.channels ?? []) {
     if (channel.name == undefined || channel.id == undefined) {
-      console.error(`channel with name ${channel.name} has undefined name or id. This should not happen.`);
+      SlackLogger.getInstance().error(`channel with name ${name} has undefined name or id. This should not happen.`);
       continue;
     }
 

--- a/src/utils/channels.ts
+++ b/src/utils/channels.ts
@@ -36,13 +36,15 @@ export function filterSlackChannelsFromNames(names: string[], channels: SlackCha
       const channel = channels.find((channel) => channel.name === name);
       // If a channel with a given name is not found, it logs an error and continues to the next name.
       if (channel == undefined) {
-        SlackLogger.getInstance().warning(`could not find channel with name ${name} when filtering channels`);
+        SlackLogger.getInstance().warning(`could not find channel with name \`${name}\` when filtering channels`);
         continue;
       }
 
       // If a channel has an undefined name or id, it logs an error and continues to the next channel.
       if (channel.name == undefined || channel.id == undefined) {
-        SlackLogger.getInstance().error(`channel with name ${name} has undefined name or id. This should not happen.`);
+        SlackLogger.getInstance().error(
+          `channel with name \`${name}\` has undefined name or id. This should not happen.`,
+        );
         continue;
       }
 
@@ -79,7 +81,9 @@ export async function getAllSlackChannels(client: WebClient): Promise<SlackChann
 
   for (const channel of channels.channels ?? []) {
     if (channel.name == undefined || channel.id == undefined) {
-      SlackLogger.getInstance().error(`channel with name ${name} has undefined name or id. This should not happen.`);
+      SlackLogger.getInstance().error(
+        `channel with name \`${channel.name}\` has undefined name or id. This should not happen.`,
+      );
       continue;
     }
 

--- a/src/utils/channels.ts
+++ b/src/utils/channels.ts
@@ -14,7 +14,7 @@ import { SlackLogger } from "../classes/SlackLogger";
 export function filterSlackChannelFromName(name: string, channels: SlackChannel[]): SlackChannel | undefined {
   if (name == "default") throw new Error("`default` is not a valid channel name, as it is a group of channels");
   const channel = channels?.find((channel) => channel.name === name);
-  if (channel == undefined) throw new Error(`could not find channel with name ${name}`);
+  if (channel == undefined) throw new Error(`could not find channel with name "${name}"`);
 
   return channel;
 }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -10,3 +10,4 @@ export const googleAccountClient = process.env.GOOGLE_ACCOUNT_CLIENT;
 export const googleAccountSecret = process.env.GOOGLE_ACCOUNT_SECRET;
 export const googleAccountToken = process.env.GOOGLE_ACCOUNT_TOKEN;
 export const googleAccountOauthRedirect = process.env.GOOGLE_ACCOUNT_OAUTH_REDIRECT;
+export const deploymentCommitHash = process.env.DEPLOY_COMMIT_SHA;

--- a/src/utils/eventReminders.ts
+++ b/src/utils/eventReminders.ts
@@ -8,6 +8,7 @@ import { generateEmojiPair } from "./slackEmojis";
 import SlackChannel from "../classes/SlackChannel";
 import SlackUser from "../classes/SlackUser";
 import { postMessageToSingleChannelGuestsInChannels } from "./users";
+import { SlackLogger } from "../classes/SlackLogger";
 
 /**
  * The interval in milliseconds at which the scheduled event checking task runs
@@ -103,7 +104,7 @@ export async function remindUpcomingEvent(
     allSlackUsersInWorkspace,
   );
 
-  console.log(
+  SlackLogger.getInstance().info(
     `Sent reminder for event "${event.title}" at ${event.start} to #${event.minervaEventMetadata.channel.name} and ${singleChannelGuestsMessaged} single channel guests`,
   );
 }
@@ -129,7 +130,12 @@ export async function postReminderToChannel(
       unfurl_media: false,
     });
   } catch (error) {
-    console.error("Failed to post message to channel with error:", error);
+    SlackLogger.getInstance().error(
+      `Failed to post reminder message to channel ${channel.name} with error:
+\`\`\`
+${error}
+\`\`\``,
+    );
     return;
   }
 
@@ -144,7 +150,12 @@ export async function postReminderToChannel(
       try {
         await addReactionToMessage(client, channel.id, emoji, timestamp);
       } catch (error) {
-        console.error(`Failed to add reaction ${emoji} to message ${timestamp} with error ${error}`);
+        SlackLogger.getInstance()
+          .error(`Failed to add reaction ${emoji} to message ${timestamp} in ${channel.name} with error 
+\`\`\`        
+${error}
+\`\`\`
+`);
       }
     });
   }

--- a/src/utils/eventReminders.ts
+++ b/src/utils/eventReminders.ts
@@ -138,7 +138,7 @@ export async function postReminderToChannel(
   } catch (error) {
     SlackLogger.getInstance().error(
       `Failed to post reminder message to channel \`${channel.name}\` with error:`,
-      String(error),
+      error,
     );
     return;
   }
@@ -156,7 +156,7 @@ export async function postReminderToChannel(
       } catch (error) {
         SlackLogger.getInstance().error(
           `Failed to add reaction \`${emoji}\` to message \`${timestamp}\` in \`${channel.name}\` with error:`,
-          String(error),
+          error,
         );
       }
     });

--- a/src/utils/eventReminders.ts
+++ b/src/utils/eventReminders.ts
@@ -104,8 +104,14 @@ export async function remindUpcomingEvent(
     allSlackUsersInWorkspace,
   );
 
+  const reminderTypeString = reminderType === EventReminderType.FIVE_MINUTES ? "5 minute" : "6 hour";
+
   SlackLogger.getInstance().info(
-    `Sent reminder for event \`${event.title}\` at \`${event.start}\` to \`${event.minervaEventMetadata.channel.name}\` and ${singleChannelGuestsMessaged} single channel guests`,
+    `Sent ${reminderTypeString} reminder for event \`${
+      event.title
+    }\` at \`${event.start.toISOString()}\` to channel \`${
+      event.minervaEventMetadata.channel.name
+    }\` and ${singleChannelGuestsMessaged} single channel guests`,
   );
 }
 

--- a/src/utils/eventReminders.ts
+++ b/src/utils/eventReminders.ts
@@ -105,7 +105,7 @@ export async function remindUpcomingEvent(
   );
 
   SlackLogger.getInstance().info(
-    `Sent reminder for event "${event.title}" at ${event.start} to #${event.minervaEventMetadata.channel.name} and ${singleChannelGuestsMessaged} single channel guests`,
+    `Sent reminder for event \`${event.title}\` at \`${event.start}\` to \`${event.minervaEventMetadata.channel.name}\` and ${singleChannelGuestsMessaged} single channel guests`,
   );
 }
 
@@ -131,10 +131,8 @@ export async function postReminderToChannel(
     });
   } catch (error) {
     SlackLogger.getInstance().error(
-      `Failed to post reminder message to channel ${channel.name} with error:
-\`\`\`
-${error}
-\`\`\``,
+      `Failed to post reminder message to channel \`${channel.name}\` with error:`,
+      String(error),
     );
     return;
   }
@@ -150,12 +148,10 @@ ${error}
       try {
         await addReactionToMessage(client, channel.id, emoji, timestamp);
       } catch (error) {
-        SlackLogger.getInstance()
-          .error(`Failed to add reaction ${emoji} to message ${timestamp} in ${channel.name} with error 
-\`\`\`        
-${error}
-\`\`\`
-`);
+        SlackLogger.getInstance().error(
+          `Failed to add reaction \`${emoji}\` to message \`${timestamp}\` in \`${channel.name}\` with error:`,
+          String(error),
+        );
       }
     });
   }

--- a/src/utils/googleCalendar.ts
+++ b/src/utils/googleCalendar.ts
@@ -39,7 +39,7 @@ export function parseEvents(events: calendar_v3.Schema$Events, channels: SlackCh
         const calendarEvent = CalendarEvent.fromGoogleCalendarEvent(event, channels);
         eventsList.push(calendarEvent);
       } catch (error) {
-        SlackLogger.getInstance().error(`Failed to parse Google Calendar event:`, String(error));
+        SlackLogger.getInstance().error(`Failed to parse Google Calendar event:`, error);
       }
     });
 

--- a/src/utils/googleCalendar.ts
+++ b/src/utils/googleCalendar.ts
@@ -2,6 +2,7 @@ import { OAuth2Client } from "google-auth-library";
 import { google, calendar_v3 } from "googleapis";
 import CalendarEvent from "../classes/CalendarEvent";
 import SlackChannel from "../classes/SlackChannel";
+import { SlackLogger } from "../classes/SlackLogger";
 
 /**
  * Fetches all events in the next 24 hours from the Rocketry calendar.
@@ -34,8 +35,12 @@ export function parseEvents(events: calendar_v3.Schema$Events, channels: SlackCh
   const eventsList: CalendarEvent[] = [];
   if (events.items) {
     events.items.forEach((event) => {
-      const calendarEvent = CalendarEvent.fromGoogleCalendarEvent(event, channels);
-      eventsList.push(calendarEvent);
+      try {
+        const calendarEvent = CalendarEvent.fromGoogleCalendarEvent(event, channels);
+        eventsList.push(calendarEvent);
+      } catch (error) {
+        SlackLogger.getInstance().error(`Failed to parse Google Calendar event:`, String(error));
+      }
     });
 
     return eventsList;

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,0 +1,12 @@
+import { SlashCommand } from "@slack/bolt";
+import { SlackLogger } from "../classes/SlackLogger";
+
+/**
+ * Logs the use of a slash command.
+ * @param command - The slash command to log.
+ */
+export async function logCommandUsed(command: SlashCommand): Promise<void> {
+  await SlackLogger.getInstance().info(
+    `${command.user_name} used the ${command.command} command in ${command.channel_name}`,
+  );
+}

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -7,6 +7,6 @@ import { SlackLogger } from "../classes/SlackLogger";
  */
 export async function logCommandUsed(command: SlashCommand): Promise<void> {
   await SlackLogger.getInstance().info(
-    `${command.user_name} used the ${command.command} command in ${command.channel_name}`,
+    `\`${command.user_name}\` used the \`${command.command}\` command in \`${command.channel_name}\``,
   );
 }

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -154,7 +154,7 @@ export async function getAllSlackUsers(
  * @param channelId The id of the Slack channel.
  * @returns A promise that resolves to an array of SlackUserIDs in the channel, or undefined if the channel is not found.
  */
-export async function getChannelMembers(client: WebClient, channelId: string): Promise<SlackUserID[] | undefined> {
+export async function getChannelMembers(client: WebClient, channelId: string): Promise<SlackUserID[]> {
   try {
     let cursor: string | undefined = undefined;
     const members: SlackUserID[] = [];
@@ -175,7 +175,7 @@ export async function getChannelMembers(client: WebClient, channelId: string): P
         break;
       }
     }
-    return members.length > 0 ? members : undefined;
+    return members.length > 0 ? members : [];
   } catch (error) {
     SlackLogger.getInstance().error(`Failed to get members for channel with id \`${channelId}\`:`, String(error));
     throw error;

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -80,7 +80,7 @@ export async function postEphemeralMessage(
     return res;
   } catch (error) {
     SlackLogger.getInstance().error(
-      `Failed to post ephemeral message to channel \`${channel}\` with error:`,
+      `Failed to post ephemeral message to user \`${user}\` in channel \`${channel}\` with error:`,
       String(error),
     );
     throw error;

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -45,7 +45,7 @@ export async function postMessage(
       ...options,
     });
   } catch (error) {
-    SlackLogger.getInstance().error(`Failed to post message to channel \`${channel.name}\` with error:`, String(error));
+    SlackLogger.getInstance().error(`Failed to post message to channel \`${channel.name}\` with error:`, error);
     throw error;
   }
 
@@ -81,7 +81,7 @@ export async function postEphemeralMessage(
   } catch (error) {
     SlackLogger.getInstance().error(
       `Failed to post ephemeral message to user \`${user}\` in channel \`${channel}\` with error:`,
-      String(error),
+      error,
     );
     throw error;
   }
@@ -101,7 +101,7 @@ export async function getAllEmoji(client: WebClient): Promise<string[]> {
     }
     return Object.keys(result.emoji);
   } catch (error) {
-    SlackLogger.getInstance().error(`Failed to get emojis for workspace:`, String(error));
+    SlackLogger.getInstance().error(`Failed to get emojis for workspace:`, error);
     throw error;
   }
 }
@@ -141,7 +141,7 @@ export async function getAllSlackUsers(
         break;
       }
     } catch (error) {
-      SlackLogger.getInstance().error(`Failed to get users from workspace:`, String(error));
+      SlackLogger.getInstance().error(`Failed to get users from workspace:`, error);
       throw error;
     }
   }
@@ -177,7 +177,7 @@ export async function getChannelMembers(client: WebClient, channelId: string): P
     }
     return members.length > 0 ? members : [];
   } catch (error) {
-    SlackLogger.getInstance().error(`Failed to get members for channel with id \`${channelId}\`:`, String(error));
+    SlackLogger.getInstance().error(`Failed to get members for channel with id \`${channelId}\`:`, error);
     throw error;
   }
 }
@@ -209,7 +209,7 @@ export function addReactionToMessage(
   } catch (error) {
     SlackLogger.getInstance().error(
       `Failed to add reaction \`${emoji}\` to message \`${timestampStr}\` in \`${channel}\`:`,
-      String(error),
+      error,
     );
     throw error;
   }
@@ -236,7 +236,7 @@ export async function getMessagePermalink(
   } catch (error) {
     SlackLogger.getInstance().error(
       `Error fetching message permalink for message with timestamp \`${timestamp}\` in \`${channel}\`:`,
-      String(error),
+      error,
     );
     throw error;
   }

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -4,6 +4,7 @@ import SlackUser, { UserType } from "../classes/SlackUser";
 import SlackChannel from "../classes/SlackChannel";
 import { determineUserType } from "./users";
 import { ReactionsAddResponse } from "@slack/web-api";
+import { SlackLogger } from "../classes/SlackLogger";
 
 export type SlackUserID = string;
 
@@ -64,7 +65,11 @@ export async function getAllEmoji(client: WebClient): Promise<string[]> {
     }
     return Object.keys(result.emoji);
   } catch (error) {
-    console.error("Failed to get emoji:", error);
+    SlackLogger.getInstance().error(`Failed to get emojis for workspace: 
+\`\`\`
+${error}
+\`\`\`
+    `);
     throw error;
   }
 }
@@ -135,7 +140,11 @@ export async function getChannelMembers(client: WebClient, channelId: string): P
     }
     return members.length > 0 ? members : undefined;
   } catch (error) {
-    console.error("Error fetching channel members:", error);
+    SlackLogger.getInstance().error(`Failed to get members for channel with id ${channelId}:
+\`\`\`
+${error}
+\`\`\`
+    `);
     return undefined;
   }
 }
@@ -184,7 +193,13 @@ export async function getMessagePermalink(
       message_ts: timestamp,
     });
   } catch (error) {
-    console.error(`Error fetching message permalink for message with timestamp ${timestamp} in ${channel}`, error);
+    SlackLogger.getInstance()
+      .error(`Error fetching message permalink for message with timestamp ${timestamp} in ${channel}:
+\`\`\`
+${error}
+\`\`\`
+    `);
+    return;
   }
 
   if (res?.ok) {

--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -113,7 +113,7 @@ export async function getAllSingleChannelGuestsInOneChannel(
   try {
     allUsersInChannel = await getAllUsersInChannel(client, channel.name);
   } catch (error) {
-    SlackLogger.getInstance().error(`Failed to get users in channel \`${channel.name}\` with error:`, String(error));
+    SlackLogger.getInstance().error(`Failed to get users in channel \`${channel.name}\` with error:`, error);
     throw error;
   }
 

--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -6,6 +6,7 @@ import SlackUser, { UserType } from "../classes/SlackUser";
 import { Member } from "@slack/web-api/dist/response/UsersListResponse";
 import { filterSlackChannelFromName, getAllSlackChannels } from "./channels";
 import { SlackUserID, getAllSlackUsers, getChannelMembers, postMessage } from "./slack";
+import { SlackLogger } from "../classes/SlackLogger";
 
 /**
  * Determine the type of a Slack user based on the provided Member object.
@@ -58,7 +59,7 @@ export async function getAllSingleChannelGuests(slackUsers: SlackUser[]): Promis
  * @returns A promise that resolves to an array of user IDs in the channel,
  *   or undefined if the channel is not found.
  */
-export async function getAllUsersInChannel(client: WebClient, channel: string): Promise<SlackUserID[] | undefined> {
+export async function getAllUsersInChannel(client: WebClient, channel: string): Promise<SlackUserID[]> {
   const allSlackChannels = await getAllSlackChannels(client);
   const channelId = await filterSlackChannelFromName(channel, allSlackChannels);
   if (!channelId) {
@@ -108,7 +109,13 @@ export async function getAllSingleChannelGuestsInOneChannel(
   channel: SlackChannel,
   allUsersInWorkspace?: SlackUser[],
 ): Promise<SlackUser[]> {
-  const allUsersInChannel = await getAllUsersInChannel(client, channel.name);
+  let allUsersInChannel: SlackUserID[] = [];
+  try {
+    allUsersInChannel = await getAllUsersInChannel(client, channel.name);
+  } catch (error) {
+    SlackLogger.getInstance().error(`Failed to get users in channel \`${channel.name}\` with error:`, String(error));
+    throw error;
+  }
 
   if (allUsersInWorkspace == undefined) {
     allUsersInWorkspace = await getAllSlackUsers(client);

--- a/tests/unit/utils/calendarDescription.test.ts
+++ b/tests/unit/utils/calendarDescription.test.ts
@@ -160,7 +160,7 @@ describe("utils/calendarDescription", () => {
 
     it("should throw an error if the the channel specified does not exist", () => {
       const description = `#foodstuffs<br>This is a description<br>Yep it is.`;
-      expect(() => parseDescription(description, [])).toThrow("could not find channel with name foodstuffs");
+      expect(() => parseDescription(description, [])).toThrow(`could not find channel with name "foodstuffs"`);
     });
 
     it("should throw an error if no channel is specified", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ES2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */


### PR DESCRIPTION
## Description
<!-- Add background/context for the PR (why are we making these changes?) and a description of the changes that this makes. -->
Previously, we were using RTail to view the logs for minerva, which was a bit of a buggy mess and a bad experience as it made use of UDP to stream logs and therefore they tended to be out of order a lot of the time. This PR aims to fix this by aligning our method of logging to something similar to what was done in old minerva: having Minerva post log messages in the `#minerva-log` channel in Slack.

<!-- Replace "00" with the relevant GitHub issue number. -->
<!-- e.g. https://github.com/waterloo-rocketry/minerva-rewrite/issues/44 has issue #44 -->
This PR closes #58 .

## Developer Testing
<!-- Outline steps that you have taken to test your newly implemented functionality. e.g. implementing new unit tests, steps taken for manual testing, etc. -->
Testing done:
- Manually tested instances of each logging type by triggering them through temporary code or by running commands in Slack
- Automated unit tests are blocked by #55 

## Reviewer Testing
<!-- Provide some steps that reviewers can take to test your functionality (or just view the new feature) on their side.  -->
<!-- Note that much of minerva's functionality needs to be tested on the Dev Slack, so you should write these steps accordingly -->

Steps to view reminder message sending logging:
1. Create a Google Calendar event on the Dev Google Calendar, making sure to add all the necessary metadata (minimally, a channel name - ensure that channel actually exists in the dev slack)
1. Move the event to a suitable start time to test the functionality with (e.g. moving the event to +5 mins or +6 hours from the next five-minute mark is good to test those meeting reminders)
1. Wait for the five-minute mark so the function executes
1. Verify the message that was logged to the `#minerva-log` channel

Steps to view command run logging
1. Run a minerva command in slack (for now, `/help` is the only one that exists)
2. Verify the message that was logged to the `#minerva-log` channel

Steps to view error logging
1. Create a google calendar event (as outlined previously), but set the channel name to be for one that does not exist
2.  Verify the message that was logged to the `#minerva-log` channel

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/66)
<!-- Reviewable:end -->
