### PR TITLE
Provide `eventTypes` param for `calendar.events.list`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/moment-timezone": "^0.5.30",
     "@types/node-schedule": "^2.1.5",
     "dotenv": "^16.3.1",
-    "googleapis": "^129.0.0",
+    "googleapis": "^133.0.0",
     "html-to-text": "^9.0.5",
     "moment-timezone": "^0.5.44",
     "node-schedule": "^2.1.1"

--- a/src/utils/googleCalendar.ts
+++ b/src/utils/googleCalendar.ts
@@ -16,6 +16,7 @@ export async function getEvents(auth: OAuth2Client): Promise<calendar_v3.Schema$
   const getNextEvents = await calendar.events.list({
     auth: auth,
     calendarId: "primary",
+    eventTypes: ["default"],
     timeMin: currentTime.toISOString(),
     timeMax: next24Hours.toISOString(),
     singleEvents: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3994,13 +3994,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"googleapis@npm:^129.0.0":
-  version: 129.0.0
-  resolution: "googleapis@npm:129.0.0"
+"googleapis@npm:^133.0.0":
+  version: 133.0.0
+  resolution: "googleapis@npm:133.0.0"
   dependencies:
     google-auth-library: ^9.0.0
     googleapis-common: ^7.0.0
-  checksum: ce694221b9e53195761a8e08452dd60919afe6a0f397720384a638dba4ae1d6d0a2c2bf4a8c78630e631b4f69137036bb3a5d87629ec82e33ef2eead732986c5
+  checksum: 2e18f8da13e04d7d05d83b293d44ba7da2ed06789357869ca39725ac77144f0e4dc6a2ae1dc7f4de715821cccedebffa9c2c7e718cc7c03774239e9c4c8cc63f
   languageName: node
   linkType: hard
 
@@ -5650,7 +5650,7 @@ __metadata:
     eslint-config-prettier: ^9.0.0
     eslint-plugin-jsdoc: ^48.0.2
     eslint-plugin-prettier: ^5.0.0
-    googleapis: ^129.0.0
+    googleapis: ^133.0.0
     html-to-text: ^9.0.5
     jest: ^29.7.0
     moment-timezone: ^0.5.44


### PR DESCRIPTION
## Description
<!-- Add background/context for the PR (why are we making these changes?) and a description of the changes that this makes. -->
Due to soon-to-come changes to the Google Calendar API:
![image](https://github.com/waterloo-rocketry/minerva-rewrite/assets/8643561/29387e0b-181f-484e-a218-0b6a6fcb441b)
...changed the `calendar.events.list` call to only list "default" events. You can read more about event types [here](https://developers.google.com/calendar/api/v3/reference/events/list#parameters), and the new change [here](https://developers.google.com/calendar/docs/release-notes#February_07_2024)

## Developer Testing
<!-- Outline steps that you have taken to test your newly implemented functionality. e.g. implementing new unit tests, steps taken for manual testing, etc. -->
Testing done:
- Manually tested to ensure that the API call was still working as expected

## Reviewer Testing
None Required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/68)
<!-- Reviewable:end -->
