### PR TITLE
Implement `/notify` command

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -25,3 +25,6 @@ export const loggingChannel =
   environment == "production"
     ? new SlackChannel("minerva-log", "C016AAGP83F")
     : new SlackChannel("minerva-log", "C015FSK7FQE");
+
+export const slackWorkspaceUrl =
+  environment == "production" ? "https://waterloorocketry.slack.com" : "https://waterloorocketrydev.slack.com";

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -4,7 +4,7 @@ import SlackChannel from "../classes/SlackChannel";
 /**
  * The "default" slack channels for use in sending DM reminders to single-channel guests
  */
-export const defaultSlackChannels =
+export const defaultSlackChannelNames =
   environment == "production"
     ? [
         "general",

--- a/src/listeners/commands/helpCommand.ts
+++ b/src/listeners/commands/helpCommand.ts
@@ -4,9 +4,11 @@ import { postEphemeralMessage } from "../../utils/slack";
 
 const message = `For more information, check out <https://github.com/waterloo-rocketry/minerva-rewrite/blob/main/README.md|minerva's README>.`;
 
-export const helpCommandHandler: Middleware<SlackCommandMiddlewareArgs> = async ({ command, ack, client }) => {
+const helpCommandHandler: Middleware<SlackCommandMiddlewareArgs> = async ({ command, ack, client }) => {
   await ack();
   await logCommandUsed(command);
 
   await postEphemeralMessage(client, command.channel_id, command.user_id, message);
 };
+
+export default helpCommandHandler;

--- a/src/listeners/commands/helpCommand.ts
+++ b/src/listeners/commands/helpCommand.ts
@@ -1,14 +1,26 @@
-import { Middleware, SlackCommandMiddlewareArgs } from "@slack/bolt";
+import { SlackCommandMiddlewareArgs, AllMiddlewareArgs } from "@slack/bolt";
+import { StringIndexed } from "@slack/bolt/dist/types/helpers";
+
 import { logCommandUsed } from "../../utils/logging";
 import { postEphemeralMessage } from "../../utils/slack";
 
 const message = `For more information, check out <https://github.com/waterloo-rocketry/minerva-rewrite/blob/main/README.md|minerva's README>.`;
 
-const helpCommandHandler: Middleware<SlackCommandMiddlewareArgs> = async ({ command, ack, client }) => {
+/**
+ * Handles the /help command
+ * @param obj The arguments for the middleware
+ * @param obj.ack The Bolt app's `ack()` function
+ * @param obj.command The command payload
+ * @param obj.client The Bolt app client
+ * @returns A promise of void
+ */
+export default async function helpCommandHandler({
+  ack,
+  command,
+  client,
+}: SlackCommandMiddlewareArgs & AllMiddlewareArgs<StringIndexed>): Promise<void> {
   await ack();
   await logCommandUsed(command);
 
   await postEphemeralMessage(client, command.channel_id, command.user_id, message);
-};
-
-export default helpCommandHandler;
+}

--- a/src/listeners/commands/index.ts
+++ b/src/listeners/commands/index.ts
@@ -1,10 +1,11 @@
 // commands/index.ts
 import { App } from "@slack/bolt";
-import { helpCommandHandler } from "./helpCommand";
+import helpCommandHandler from "./helpCommand";
+import notifyCommandHandler from "./notifyCommand";
 
 const register = (app: App): void => {
   app.command("/help", helpCommandHandler);
-  // Other command registrations would go here
+  app.command("/notify", notifyCommandHandler);
 };
 
 export default { register };

--- a/src/listeners/commands/notifyCommand.ts
+++ b/src/listeners/commands/notifyCommand.ts
@@ -1,35 +1,86 @@
-import { Middleware, SlackCommandMiddlewareArgs } from "@slack/bolt";
+import { AllMiddlewareArgs, SlackCommandMiddlewareArgs } from "@slack/bolt";
+import { StringIndexed } from "@slack/bolt/dist/types/helpers";
+
 import { logCommandUsed } from "../../utils/logging";
 import { postEphemeralMessage } from "../../utils/slack";
 import SlackChannel from "../../classes/SlackChannel";
 import { getDefaultSlackChannels, parseEscapedSlashCommandChannel } from "../../utils/channels";
+import { slackWorkspaceUrl } from "../../common/constants";
+import { SlackLogger } from "../../classes/SlackLogger";
 
-export const notifyCommandHandler: Middleware<SlackCommandMiddlewareArgs> = async ({ command, ack, client }) => {
+type NotifyParameters = {
+  messageUrl: string;
+  pingChannels: boolean;
+  channels: SlackChannel[] | "default";
+};
+
+/**
+ * Handles the /notify command
+ * @param obj The arguments for the middleware
+ * @param obj.ack The Bolt app's `ack()` function
+ * @param obj.command The command payload
+ * @param obj.client The Bolt app client
+ * @returns A promise of void
+ */
+export default async function notifyCommandHandler({
+  ack,
+  command,
+  client,
+}: SlackCommandMiddlewareArgs & AllMiddlewareArgs<StringIndexed>): Promise<void> {
   await ack();
   await logCommandUsed(command);
 
-  const tokens = command.text.split(" ");
+  let notifyParams: NotifyParameters;
 
-  if (tokens.length == 0) {
-    postEphemeralMessage(
-      client,
-      command.channel_id,
-      command.user_id,
-      "Please provide a message to send. Usage: `/notify <messageURL>`",
-    );
+  try {
+    notifyParams = parseNotifyCommand(command.text);
+  } catch (e) {
+    if (e instanceof Error) {
+      await postEphemeralMessage(client, command.channel_id, command.user_id, e.message);
+    } else {
+      await postEphemeralMessage(client, command.channel_id, command.user_id, "An unknown error occurred.");
+    }
+
     return;
   }
 
+  let { channels } = notifyParams;
+  const { messageUrl, pingChannels } = notifyParams;
+
+  const message = pingChannels ? `<!channel>\n${messageUrl}` : messageUrl;
+
+  if (channels == "default") {
+    channels = await getDefaultSlackChannels(client);
+  }
+
+  for (const channel of channels) {
+    await client.chat.postMessage({
+      channel: channel.id,
+      text: message,
+    });
+  }
+
+  SlackLogger.getInstance().info(
+    `Notified channels ${channels.map((c) => `\`${c.name}\``).join(", ")} about message \`${messageUrl}\``,
+  );
+}
+
+/**
+ * Parses the `/notify` command and returns the parameters
+ * @param command The arguments of the `/notify` command
+ * @returns The parameters for the notify command
+ */
+function parseNotifyCommand(command: string): NotifyParameters {
+  const tokens = command.split(" ");
+
+  if (tokens.length == 0) {
+    throw new Error("Please provide a message to send. Usage: `/notify <messageURL>`");
+  }
+
   // Check if first token is a valid URL
-  const url = tokens.shift() as string;
-  if (!url.startsWith("http")) {
-    postEphemeralMessage(
-      client,
-      command.channel_id,
-      command.user_id,
-      "Please provide a valid message URL as the first argument.",
-    );
-    return;
+  const messageUrl = tokens.shift() as string;
+  if (!messageUrl.startsWith(`${slackWorkspaceUrl}/archives/`)) {
+    throw new Error("Please provide a valid message URL from this Slack workspace as the first argument.");
   }
 
   let pingChannels = false;
@@ -39,37 +90,21 @@ export const notifyCommandHandler: Middleware<SlackCommandMiddlewareArgs> = asyn
     tokens.shift();
   }
 
-  // If no channels specified, send to default
-  let channels: SlackChannel[] = [];
+  let channels: SlackChannel[] | "default" = [];
 
-  if (tokens.length == 1) {
-    channels = await getDefaultSlackChannels(client);
+  if (tokens.length == 0) {
+    channels = "default";
   } else {
     for (const channelString of tokens) {
       let channel: SlackChannel;
       try {
         channel = parseEscapedSlashCommandChannel(channelString);
       } catch (e) {
-        postEphemeralMessage(
-          client,
-          command.channel_id,
-          command.user_id,
-          `Error parsing channel \`${channelString}\`: ${e}`,
-        );
-        return;
+        throw new Error(`Error parsing channel \`${channelString}\`: ${e}`);
       }
       channels.push(channel);
     }
   }
 
-  const message = pingChannels ? `<!channel>\n${url}` : url;
-
-  for (const channel of channels) {
-    await client.chat.postMessage({
-      channel: channel.id,
-      text: message,
-    });
-  }
-};
-
-export default notifyCommandHandler;
+  return { messageUrl, pingChannels, channels };
+}

--- a/src/listeners/commands/notifyCommand.ts
+++ b/src/listeners/commands/notifyCommand.ts
@@ -1,5 +1,4 @@
 import { AllMiddlewareArgs, SlackCommandMiddlewareArgs } from "@slack/bolt";
-import { StringIndexed } from "@slack/bolt/dist/types/helpers";
 
 import { logCommandUsed } from "../../utils/logging";
 import { postEphemeralMessage } from "../../utils/slack";
@@ -23,10 +22,10 @@ type NotifyParameters = {
  * @returns A promise of void
  */
 export default async function notifyCommandHandler({
-  ack,
   command,
+  ack,
   client,
-}: SlackCommandMiddlewareArgs & AllMiddlewareArgs<StringIndexed>): Promise<void> {
+}: SlackCommandMiddlewareArgs & AllMiddlewareArgs): Promise<void> {
   await ack();
   await logCommandUsed(command);
 

--- a/src/listeners/commands/notifyCommand.ts
+++ b/src/listeners/commands/notifyCommand.ts
@@ -7,7 +7,7 @@ import { getDefaultSlackChannels, parseEscapedSlashCommandChannel } from "../../
 import { slackWorkspaceUrl } from "../../common/constants";
 import { SlackLogger } from "../../classes/SlackLogger";
 
-type NotifyParameters = {
+export type NotifyParameters = {
   messageUrl: string;
   pingChannels: boolean;
   channels: SlackChannel[] | "default";
@@ -69,15 +69,16 @@ export default async function notifyCommandHandler({
  * @param command The arguments of the `/notify` command
  * @returns The parameters for the notify command
  */
-function parseNotifyCommand(command: string): NotifyParameters {
+export function parseNotifyCommand(command: string): NotifyParameters {
   const tokens = command.split(" ");
 
-  if (tokens.length == 0) {
+  if (tokens.length == 1 && tokens[0].trim() == "") {
     throw new Error("Please provide a message to send. Usage: `/notify <messageURL>`");
   }
 
   // Check if first token is a valid URL
-  const messageUrl = tokens.shift() as string;
+  // Links will be wrapped in < and >, so we remove those
+  const messageUrl = (tokens.shift() as string).replace(/<|>/g, "");
   if (!messageUrl.startsWith(`${slackWorkspaceUrl}/archives/`)) {
     throw new Error("Please provide a valid message URL from this Slack workspace as the first argument.");
   }

--- a/src/listeners/commands/notifyCommand.ts
+++ b/src/listeners/commands/notifyCommand.ts
@@ -132,16 +132,13 @@ export function parseNotifyCommand(command: string): NotifyParameters {
   let notifyType: NotifyType = NotifyType.DM_SINGLE_CHANNEL_GUESTS;
 
   if (tokens.length > 0) {
-    if (tokens[0] == "copy-ping") {
+    if (tokens[0] == "copy") {
+      notifyType = NotifyType.CHANNEL;
+      tokens.shift();
+    } else if (tokens[0] == "copy-ping") {
       notifyType = NotifyType.CHANNEL_PING;
       tokens.shift();
     }
-
-    if (tokens[0] == "ping") {
-      notifyType = NotifyType.CHANNEL_PING;
-    }
-
-    tokens.shift();
   }
 
   const channels: SlackChannel[] = [];

--- a/src/listeners/commands/notifyCommand.ts
+++ b/src/listeners/commands/notifyCommand.ts
@@ -1,0 +1,75 @@
+import { Middleware, SlackCommandMiddlewareArgs } from "@slack/bolt";
+import { logCommandUsed } from "../../utils/logging";
+import { postEphemeralMessage } from "../../utils/slack";
+import SlackChannel from "../../classes/SlackChannel";
+import { getDefaultSlackChannels, parseEscapedSlashCommandChannel } from "../../utils/channels";
+
+export const notifyCommandHandler: Middleware<SlackCommandMiddlewareArgs> = async ({ command, ack, client }) => {
+  await ack();
+  await logCommandUsed(command);
+
+  const tokens = command.text.split(" ");
+
+  if (tokens.length == 0) {
+    postEphemeralMessage(
+      client,
+      command.channel_id,
+      command.user_id,
+      "Please provide a message to send. Usage: `/notify <messageURL>`",
+    );
+    return;
+  }
+
+  // Check if first token is a valid URL
+  const url = tokens.shift() as string;
+  if (!url.startsWith("http")) {
+    postEphemeralMessage(
+      client,
+      command.channel_id,
+      command.user_id,
+      "Please provide a valid message URL as the first argument.",
+    );
+    return;
+  }
+
+  let pingChannels = false;
+
+  if (tokens.length > 0 && tokens[0] == "ping") {
+    pingChannels = true;
+    tokens.shift();
+  }
+
+  // If no channels specified, send to default
+  let channels: SlackChannel[] = [];
+
+  if (tokens.length == 1) {
+    channels = await getDefaultSlackChannels(client);
+  } else {
+    for (const channelString of tokens) {
+      let channel: SlackChannel;
+      try {
+        channel = parseEscapedSlashCommandChannel(channelString);
+      } catch (e) {
+        postEphemeralMessage(
+          client,
+          command.channel_id,
+          command.user_id,
+          `Error parsing channel \`${channelString}\`: ${e}`,
+        );
+        return;
+      }
+      channels.push(channel);
+    }
+  }
+
+  const message = pingChannels ? `<!channel>\n${url}` : url;
+
+  for (const channel of channels) {
+    await client.chat.postMessage({
+      channel: channel.id,
+      text: message,
+    });
+  }
+};
+
+export default notifyCommandHandler;

--- a/src/listeners/commands/notifyCommand.ts
+++ b/src/listeners/commands/notifyCommand.ts
@@ -82,7 +82,8 @@ export default async function notifyCommandHandler({
     return;
   }
 
-  const responseMessage = `Notified channels ${channels
+  const responseMessage = `Notified channels ${channelSet
+    .values()
     .map((c) => `\`${c.name}\``)
     .join(", ")} about message \`${messageUrl}\``;
 

--- a/src/utils/channels.ts
+++ b/src/utils/channels.ts
@@ -104,6 +104,11 @@ export async function getDefaultSlackChannels(client: WebClient): Promise<SlackC
   return defaultChannels;
 }
 
+/**
+ * Parses the escaped channel text from a Slack command and returns the Slack channel. Escaped channels are in the format <#C12345678|channel-name>
+ * @param text The escaped channel text
+ * @returns The Slack channel
+ */
 export function parseEscapedSlashCommandChannel(text: string): SlackChannel {
   // Escaped channel text is in the format <#C12345678|channel-name>
   const matches = text.match(/<#(C\w+)\|(.+)>/);

--- a/src/utils/channels.ts
+++ b/src/utils/channels.ts
@@ -1,7 +1,7 @@
 import { WebClient } from "@slack/web-api";
 import SlackChannel from "../classes/SlackChannel";
 import ObjectSet from "../classes/ObjectSet";
-import { defaultSlackChannels } from "../common/constants";
+import { defaultSlackChannelNames } from "../common/constants";
 import { SlackLogger } from "../classes/SlackLogger";
 
 /**
@@ -61,7 +61,7 @@ export function filterSlackChannelsFromNames(names: string[], channels: SlackCha
  * @returns An array of filtered default Slack channels.
  */
 export function filterDefaultSlackChannels(channels: SlackChannel[]): SlackChannel[] {
-  return filterSlackChannelsFromNames(defaultSlackChannels, channels);
+  return filterSlackChannelsFromNames(defaultSlackChannelNames, channels);
 }
 
 /**

--- a/src/utils/channels.ts
+++ b/src/utils/channels.ts
@@ -103,3 +103,15 @@ export async function getDefaultSlackChannels(client: WebClient): Promise<SlackC
   const defaultChannels = filterDefaultSlackChannels(allChannels);
   return defaultChannels;
 }
+
+export function parseEscapedSlashCommandChannel(text: string): SlackChannel {
+  // Escaped channel text is in the format <#C12345678|channel-name>
+  const matches = text.match(/<#(C\w+)\|(.+)>/);
+  if (matches == null) {
+    throw new Error(`could not parse escaped channel text: ${text}`);
+  }
+
+  const id = matches[1];
+  const name = matches[2];
+  return new SlackChannel(name, id);
+}

--- a/src/utils/channels.ts
+++ b/src/utils/channels.ts
@@ -3,6 +3,7 @@ import SlackChannel from "../classes/SlackChannel";
 import ObjectSet from "../classes/ObjectSet";
 import { defaultSlackChannelNames } from "../common/constants";
 import { SlackLogger } from "../classes/SlackLogger";
+import { slackWorkspaceUrl } from "../common/constants";
 
 /**
  * Filters a Slack channel from an array of channels based on its name.
@@ -119,4 +120,22 @@ export function parseEscapedSlashCommandChannel(text: string): SlackChannel {
   const id = matches[1];
   const name = matches[2];
   return new SlackChannel(name, id);
+}
+
+/**
+ * Extracts the channel ID from a message link.
+ * @param messageLink The message link
+ * @returns The channel ID
+ */
+export function extractChannelIdFromMessageLink(messageLink: string): string {
+  if (!messageLink.startsWith(`${slackWorkspaceUrl}/archives/`)) {
+    throw new Error(`link ${messageLink} is not a valid message link from this Slack workspace`);
+  }
+
+  const matches = messageLink.match(/\/archives\/(\w+)\/p\w+/);
+  if (matches == null) {
+    throw new Error(`could not parse message link: ${messageLink}`);
+  }
+
+  return matches[1];
 }

--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -83,6 +83,10 @@ export async function postMessageToSingleChannelGuestsInChannels(
   text: string,
   allUsersInWorkspace?: SlackUser[],
 ): Promise<number> {
+  if (allUsersInWorkspace == undefined) {
+    allUsersInWorkspace = await getAllSlackUsers(client);
+  }
+
   const allSingleChannelGuestsInChannels = await getAllSingleChannelGuestsInChannels(
     client,
     channels,

--- a/tests/fixtures/slackChannels.ts
+++ b/tests/fixtures/slackChannels.ts
@@ -1,5 +1,5 @@
 import SlackChannel from "../../src/classes/SlackChannel";
-import { defaultSlackChannels as defaultSlackChannelNames } from "../../src/common/constants";
+import { defaultSlackChannelNames } from "../../src/common/constants";
 
 export const slackChannels: SlackChannel[] = [
   new SlackChannel("admin", "C015DCM3JPN"),

--- a/tests/unit/commands/notifyCommand.test.ts
+++ b/tests/unit/commands/notifyCommand.test.ts
@@ -1,5 +1,5 @@
 import { parseNotifyCommand } from "../../../src/listeners/commands/notifyCommand";
-import { NotifyParameters } from "../../../src/listeners/commands/notifyCommand";
+import { NotifyParameters, NotifyType } from "../../../src/listeners/commands/notifyCommand";
 import SlackChannel from "../../../src/classes/SlackChannel";
 
 describe("parseNotifyCommand", () => {
@@ -7,7 +7,7 @@ describe("parseNotifyCommand", () => {
     const commandArgs = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000";
     const expected: NotifyParameters = {
       messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
-      pingChannels: false,
+      notifyType: NotifyType.DM_SINGLE_CHANNEL_GUESTS,
       includeDefaultChannels: true,
       channels: [],
     };
@@ -20,19 +20,43 @@ describe("parseNotifyCommand", () => {
     const expected: NotifyParameters = {
       messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
       includeDefaultChannels: true,
-      pingChannels: false,
+      notifyType: NotifyType.DM_SINGLE_CHANNEL_GUESTS,
       channels: [],
     };
 
     expect(parseNotifyCommand(commandArgs)).toEqual(expected);
   });
 
-  it("parses the /notify command with pinging channels", () => {
-    const commandArgs =
-      "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 ping <#C12345678|channel-name> <#C12345679|channel-name2>";
+  it("parses the /notify command with the copy flag", () => {
+    const commandArgs = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 copy";
     const expected: NotifyParameters = {
       messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
-      pingChannels: true,
+      notifyType: NotifyType.CHANNEL,
+      includeDefaultChannels: true,
+      channels: [],
+    };
+
+    expect(parseNotifyCommand(commandArgs)).toEqual(expected);
+  });
+
+  it("parses the /notify command with the copy-ping flag", () => {
+    const commandArgs = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 copy-ping";
+    const expected: NotifyParameters = {
+      messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
+      notifyType: NotifyType.CHANNEL_PING,
+      includeDefaultChannels: true,
+      channels: [],
+    };
+
+    expect(parseNotifyCommand(commandArgs)).toEqual(expected);
+  });
+
+  it("parses the /notify command with the copy-ping flag and explicit channels", () => {
+    const commandArgs =
+      "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 copy-ping <#C12345678|channel-name> <#C12345679|channel-name2>";
+    const expected: NotifyParameters = {
+      messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
+      notifyType: NotifyType.CHANNEL_PING,
       includeDefaultChannels: false,
       channels: [new SlackChannel("channel-name", "C12345678"), new SlackChannel("channel-name2", "C12345679")],
     };
@@ -40,25 +64,14 @@ describe("parseNotifyCommand", () => {
     expect(parseNotifyCommand(commandArgs)).toEqual(expected);
   });
 
-  it("parses the /notify command with the default channels", () => {
-    const commandArgs = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000";
+  it("parses the /notify command with the copy flag and explicit channels", () => {
+    const commandArgs =
+      "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 copy <#C12345678|channel-name> <#C12345679|channel-name2>";
     const expected: NotifyParameters = {
       messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
-      pingChannels: false,
-      includeDefaultChannels: true,
-      channels: [],
-    };
-
-    expect(parseNotifyCommand(commandArgs)).toEqual(expected);
-  });
-
-  it("parses the /notify command with pinging default channels", () => {
-    const commandArgs = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 ping";
-    const expected: NotifyParameters = {
-      messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
-      pingChannels: true,
-      includeDefaultChannels: true,
-      channels: [],
+      notifyType: NotifyType.CHANNEL,
+      includeDefaultChannels: false,
+      channels: [new SlackChannel("channel-name", "C12345678"), new SlackChannel("channel-name2", "C12345679")],
     };
 
     expect(parseNotifyCommand(commandArgs)).toEqual(expected);
@@ -69,7 +82,7 @@ describe("parseNotifyCommand", () => {
       "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 default <#C12345678|channel-name> <#C12345679|channel-name2>";
     const expected: NotifyParameters = {
       messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
-      pingChannels: false,
+      notifyType: NotifyType.DM_SINGLE_CHANNEL_GUESTS,
       includeDefaultChannels: true,
       channels: [new SlackChannel("channel-name", "C12345678"), new SlackChannel("channel-name2", "C12345679")],
     };
@@ -81,7 +94,7 @@ describe("parseNotifyCommand", () => {
       "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 <#C12345678|channel-name> default <#C12345679|channel-name2>";
     const expected: NotifyParameters = {
       messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
-      pingChannels: false,
+      notifyType: NotifyType.DM_SINGLE_CHANNEL_GUESTS,
       includeDefaultChannels: true,
       channels: [new SlackChannel("channel-name", "C12345678"), new SlackChannel("channel-name2", "C12345679")],
     };
@@ -90,14 +103,37 @@ describe("parseNotifyCommand", () => {
 
   it("parses the /notify command with pinging the default channels and specific channels", () => {
     const commandArgs =
-      "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 ping default <#C12345678|channel-name> <#C12345679|channel-name2>";
+      "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 copy-ping default <#C12345678|channel-name> <#C12345679|channel-name2>";
     const expected: NotifyParameters = {
       messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
-      pingChannels: true,
+      notifyType: NotifyType.CHANNEL_PING,
       includeDefaultChannels: true,
       channels: [new SlackChannel("channel-name", "C12345678"), new SlackChannel("channel-name2", "C12345679")],
     };
     expect(parseNotifyCommand(commandArgs)).toEqual(expected);
+  });
+
+  it("parses the /notify command with copy flag to the default channels and specific channels", () => {
+    const commandArgs =
+      "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 copy default <#C12345678|channel-name> <#C12345679|channel-name2>";
+    const expected: NotifyParameters = {
+      messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
+      notifyType: NotifyType.CHANNEL,
+      includeDefaultChannels: true,
+      channels: [new SlackChannel("channel-name", "C12345678"), new SlackChannel("channel-name2", "C12345679")],
+    };
+    expect(parseNotifyCommand(commandArgs)).toEqual(expected);
+  });
+
+  it("fails if both the copy and copy-ping flags are passed", () => {
+    const commandArgs = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 copy copy-ping";
+    expect(() => parseNotifyCommand(commandArgs)).toThrow();
+  });
+
+  it("fails if both the copy and copy-ping flags are passed with explicit channels specified", () => {
+    const commandArgs =
+      "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 copy copy-ping <#C12345678|channel-name> <#C12345679|channel-name2>";
+    expect(() => parseNotifyCommand(commandArgs)).toThrow();
   });
 
   it("throws an error when the command is empty", () => {

--- a/tests/unit/commands/notifyCommand.test.ts
+++ b/tests/unit/commands/notifyCommand.test.ts
@@ -1,4 +1,4 @@
-import { parseNotifyCommand } from "../../../src/listeners/commands/notifyCommand";
+import { parseNotifyCommand, generateNotifyMessage } from "../../../src/listeners/commands/notifyCommand";
 import { NotifyParameters, NotifyType } from "../../../src/listeners/commands/notifyCommand";
 import SlackChannel from "../../../src/classes/SlackChannel";
 
@@ -153,5 +153,25 @@ describe("parseNotifyCommand", () => {
   it("throws an error when the channels are invalid", () => {
     const commandArgs = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 #C12345678";
     expect(() => parseNotifyCommand(commandArgs)).toThrow();
+  });
+});
+
+describe("generateNotifyMessage", () => {
+  it("generates the notification message for NotifyType.CHANNEL", () => {
+    const messageUrl = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000";
+    const expected = `${messageUrl}`;
+    expect(generateNotifyMessage(messageUrl, NotifyType.CHANNEL)).toEqual(expected);
+  });
+
+  it("generates the notification message for NotifyType.DM_SINGLE_CHANNEL_GUESTS", () => {
+    const messageUrl = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000";
+    const expected = `${messageUrl}\n_You have been sent this message because you are a single channel guest who might have otherwise missed this alert._`;
+    expect(generateNotifyMessage(messageUrl, NotifyType.DM_SINGLE_CHANNEL_GUESTS)).toEqual(expected);
+  });
+
+  it("generates the notification message for NotifyType.CHANNEL_PING", () => {
+    const messageUrl = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000";
+    const expected = `<!channel>\n${messageUrl}`;
+    expect(generateNotifyMessage(messageUrl, NotifyType.CHANNEL_PING)).toEqual(expected);
   });
 });

--- a/tests/unit/commands/notifyCommand.test.ts
+++ b/tests/unit/commands/notifyCommand.test.ts
@@ -1,0 +1,80 @@
+import { parseNotifyCommand } from "../../../src/listeners/commands/notifyCommand";
+import { NotifyParameters } from "../../../src/listeners/commands/notifyCommand";
+import SlackChannel from "../../../src/classes/SlackChannel";
+
+describe("parseNotifyCommand", () => {
+  it("parses the /notify command", () => {
+    const commandArgs = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000";
+    const expected: NotifyParameters = {
+      messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
+      pingChannels: false,
+      channels: "default",
+    };
+
+    expect(parseNotifyCommand(commandArgs)).toEqual(expected);
+  });
+
+  it("parses the /notify command when link is not plaintext", () => {
+    const commandArgs = "<https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000>";
+    const expected: NotifyParameters = {
+      messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
+      pingChannels: false,
+      channels: "default",
+    };
+
+    expect(parseNotifyCommand(commandArgs)).toEqual(expected);
+  });
+
+  it("parses the /notify command with pinging channels", () => {
+    const commandArgs =
+      "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 ping <#C12345678|channel-name> <#C12345679|channel-name2>";
+    const expected: NotifyParameters = {
+      messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
+      pingChannels: true,
+      channels: [new SlackChannel("channel-name", "C12345678"), new SlackChannel("channel-name2", "C12345679")],
+    };
+
+    expect(parseNotifyCommand(commandArgs)).toEqual(expected);
+  });
+
+  it("parses the /notify command with the default channels", () => {
+    const commandArgs = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000";
+    const expected: NotifyParameters = {
+      messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
+      pingChannels: false,
+      channels: "default",
+    };
+
+    expect(parseNotifyCommand(commandArgs)).toEqual(expected);
+  });
+
+  it("parses the /notify command with pinging default channels", () => {
+    const commandArgs = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 ping";
+    const expected: NotifyParameters = {
+      messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
+      pingChannels: true,
+      channels: "default",
+    };
+
+    expect(parseNotifyCommand(commandArgs)).toEqual(expected);
+  });
+
+  it("throws an error when the command is empty", () => {
+    const commandArgs = "";
+    expect(() => parseNotifyCommand(commandArgs)).toThrow(
+      "Please provide a message to send. Usage: `/notify <messageURL>`",
+    );
+  });
+
+  it("throws an error when the URL is invalid", () => {
+    const commandArgs = "https://google.com";
+    expect(() => parseNotifyCommand(commandArgs)).toThrow(
+      "Please provide a valid message URL from this Slack workspace as the first argument.",
+    );
+  });
+
+  it("throws an error when the channels are invalid", () => {
+    const commandArgs = "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 #C12345678";
+    expect(() => parseNotifyCommand(commandArgs)).toThrow();
+  });
+});

--- a/tests/unit/commands/notifyCommand.test.ts
+++ b/tests/unit/commands/notifyCommand.test.ts
@@ -8,7 +8,8 @@ describe("parseNotifyCommand", () => {
     const expected: NotifyParameters = {
       messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
       pingChannels: false,
-      channels: "default",
+      includeDefaultChannels: true,
+      channels: [],
     };
 
     expect(parseNotifyCommand(commandArgs)).toEqual(expected);
@@ -18,8 +19,9 @@ describe("parseNotifyCommand", () => {
     const commandArgs = "<https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000>";
     const expected: NotifyParameters = {
       messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
+      includeDefaultChannels: true,
       pingChannels: false,
-      channels: "default",
+      channels: [],
     };
 
     expect(parseNotifyCommand(commandArgs)).toEqual(expected);
@@ -31,6 +33,7 @@ describe("parseNotifyCommand", () => {
     const expected: NotifyParameters = {
       messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
       pingChannels: true,
+      includeDefaultChannels: false,
       channels: [new SlackChannel("channel-name", "C12345678"), new SlackChannel("channel-name2", "C12345679")],
     };
 
@@ -42,7 +45,8 @@ describe("parseNotifyCommand", () => {
     const expected: NotifyParameters = {
       messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
       pingChannels: false,
-      channels: "default",
+      includeDefaultChannels: true,
+      channels: [],
     };
 
     expect(parseNotifyCommand(commandArgs)).toEqual(expected);
@@ -53,9 +57,46 @@ describe("parseNotifyCommand", () => {
     const expected: NotifyParameters = {
       messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
       pingChannels: true,
-      channels: "default",
+      includeDefaultChannels: true,
+      channels: [],
     };
 
+    expect(parseNotifyCommand(commandArgs)).toEqual(expected);
+  });
+
+  it("parses the /notify command with the default channels and specific channels", () => {
+    const commandArgs =
+      "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 default <#C12345678|channel-name> <#C12345679|channel-name2>";
+    const expected: NotifyParameters = {
+      messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
+      pingChannels: false,
+      includeDefaultChannels: true,
+      channels: [new SlackChannel("channel-name", "C12345678"), new SlackChannel("channel-name2", "C12345679")],
+    };
+    expect(parseNotifyCommand(commandArgs)).toEqual(expected);
+  });
+
+  it("parses the /notify command with the default channels and specific channels (default not first)", () => {
+    const commandArgs =
+      "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 <#C12345678|channel-name> default <#C12345679|channel-name2>";
+    const expected: NotifyParameters = {
+      messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
+      pingChannels: false,
+      includeDefaultChannels: true,
+      channels: [new SlackChannel("channel-name", "C12345678"), new SlackChannel("channel-name2", "C12345679")],
+    };
+    expect(parseNotifyCommand(commandArgs)).toEqual(expected);
+  });
+
+  it("parses the /notify command with pinging the default channels and specific channels", () => {
+    const commandArgs =
+      "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000 ping default <#C12345678|channel-name> <#C12345679|channel-name2>";
+    const expected: NotifyParameters = {
+      messageUrl: "https://waterloorocketrydev.slack.com/archives/C015FXXXXXX/p1707843500000000",
+      pingChannels: true,
+      includeDefaultChannels: true,
+      channels: [new SlackChannel("channel-name", "C12345678"), new SlackChannel("channel-name2", "C12345679")],
+    };
     expect(parseNotifyCommand(commandArgs)).toEqual(expected);
   });
 

--- a/tests/unit/utils/channels.test.ts
+++ b/tests/unit/utils/channels.test.ts
@@ -1,4 +1,4 @@
-import { parseEscapedSlashCommandChannel } from "../../../src/utils/channels";
+import { parseEscapedSlashCommandChannel, extractChannelIdFromMessageLink } from "../../../src/utils/channels";
 
 describe("parseEscapedSlashCommandChannel", () => {
   it("parses the escaped channel text from a Slack command and returns the Slack channel", () => {
@@ -14,5 +14,26 @@ describe("parseEscapedSlashCommandChannel", () => {
   it("Throws an error when the text is not in the correct format", () => {
     const text = "channel-name";
     expect(() => parseEscapedSlashCommandChannel(text)).toThrow(`could not parse escaped channel text: ${text}`);
+  });
+});
+
+describe("extractChannelIdFromMessageLink", () => {
+  it("extracts the channel ID from a message link", () => {
+    const messageLink = "https://waterloorocketrydev.slack.com/archives/C12345678/p1234567890";
+    const expected = "C12345678";
+
+    expect(extractChannelIdFromMessageLink(messageLink)).toEqual(expected);
+  });
+
+  it("Throws an error when the message link is not in the correct format", () => {
+    const messageLink = "https://waterloorocketrydev.slack.com/archives/C12345678";
+    expect(() => extractChannelIdFromMessageLink(messageLink)).toThrow(`could not parse message link: ${messageLink}`);
+  });
+
+  it("Throws an error when the message link is not from the Slack workspace", () => {
+    const messageLink = "https://notwaterloorocketrydev.slack.com/archives/C12345678/p1234567890";
+    expect(() => extractChannelIdFromMessageLink(messageLink)).toThrow(
+      `link ${messageLink} is not a valid message link from this Slack workspace`,
+    );
   });
 });

--- a/tests/unit/utils/channels.test.ts
+++ b/tests/unit/utils/channels.test.ts
@@ -1,0 +1,18 @@
+import { parseEscapedSlashCommandChannel } from "../../../src/utils/channels";
+
+describe("parseEscapedSlashCommandChannel", () => {
+  it("parses the escaped channel text from a Slack command and returns the Slack channel", () => {
+    const text = "<#C12345678|channel-name>";
+    const expected = {
+      name: "channel-name",
+      id: "C12345678",
+    };
+
+    expect(parseEscapedSlashCommandChannel(text)).toEqual(expected);
+  });
+
+  it("Throws an error when the text is not in the correct format", () => {
+    const text = "channel-name";
+    expect(() => parseEscapedSlashCommandChannel(text)).toThrow(`could not parse escaped channel text: ${text}`);
+  });
+});


### PR DESCRIPTION
## Description
<!-- Add background/context for the PR (why are we making these changes?) and a description of the changes that this makes. -->
Implemented the `/notify` command, which allows the user to either repost a message to specified channels or DM single-channels guests in those channels with the message. 

<!-- Replace "00" with the relevant GitHub issue number. -->
<!-- e.g. https://github.com/waterloo-rocketry/minerva-rewrite/issues/44 has issue #44 -->
This PR closes #23 

## Developer Testing
<!-- Outline steps that you have taken to test your newly implemented functionality. e.g. implementing new unit tests, steps taken for manual testing, etc. -->
Testing done:
- Implemented unit tests for `parseNotifyCommand()` and `parseEscapedSlashCommandChannel()`
- Manually tested edge-cases on the development slack

## Reviewer Testing
<!-- Provide some steps that reviewers can take to test your functionality (or just view the new feature) on their side.  -->
<!-- Note that much of minerva's functionality needs to be tested on the Dev Slack, so you should write these steps accordingly -->

Steps to view/test Command
1. Copy the link to a message to use for the command
2. Run the `/notify` command in a channel with the copied link provided and `copy` argument passed (i.e. `/notify [link] copy`) and ensure that it is reposted to all default channels. Note that it will not repost to the channel that the message is in.
3. Run the `/notify` command with specific channels specified (i.e. `/notify [link] copy #general #test`) and ensure that it is reposted to all the specified channels.
4. Run the `/notify` command with the `copy-ping` argument specified (i.e. `/notify copy-ping [link] ping`) and ensure that the message is reposted and the messages ping `@channel`
5. Run the `/notify` command with just the link provided (i.e. `/notify [link]`) and ensure that any admins (stand-ins for single-channel guests) are DMd the message

Please also notify the feature reference document for this command: https://docs.google.com/document/d/1otYHtmFHzkN8g7089EGQpxi9-7C_iKFhDt2L2tuwxHs/edit#heading=h.8w6auka00s3p
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/69)
<!-- Reviewable:end -->
