### PR TITLE
Implement no-dm flag

### DIFF
--- a/src/listeners/commands/helpCommand.ts
+++ b/src/listeners/commands/helpCommand.ts
@@ -5,9 +5,9 @@ import { logCommandUsed } from "../../utils/logging";
 import { postEphemeralMessage } from "../../utils/slack";
 import { SlackLogger } from "../../classes/SlackLogger";
 
-const message = `For guides on how to use minerva's functionality, check out the feature reference guides in the Google Drive (<https://drive.google.com/drive/u/1/folders/1h7FZKuF3Zvv8EygjB8pSTk2aGuHHpBtj|link>) 
-* <https://docs.google.com/document/d/1KbeJtU06Uosjpd3XlvEGtElOx5lAZz9vDe8yzHyFhvU/edit#heading=h.g3pdvke98aqf|Meeting Reminders>
-* <https://docs.google.com/document/d/1otYHtmFHzkN8g7089EGQpxi9-7C_iKFhDt2L2tuwxHs/edit#heading=h.8w6auka00s3p|Message Notifications>
+const message = `For instructions on how to use minerva's functionality, check out the feature reference guides in the Google Drive (<https://drive.google.com/drive/u/1/folders/1h7FZKuF3Zvv8EygjB8pSTk2aGuHHpBtj|link>) 
+• <https://docs.google.com/document/d/1KbeJtU06Uosjpd3XlvEGtElOx5lAZz9vDe8yzHyFhvU/edit#heading=h.g3pdvke98aqf|Meeting Reminders>
+• <https://docs.google.com/document/d/1otYHtmFHzkN8g7089EGQpxi9-7C_iKFhDt2L2tuwxHs/edit#heading=h.8w6auka00s3p|Message Notifications>
 `;
 
 /**

--- a/src/listeners/commands/notifyCommand.ts
+++ b/src/listeners/commands/notifyCommand.ts
@@ -100,7 +100,7 @@ export default async function notifyCommandHandler({
 
   const responseMessage = `Notified ${
     notifyType == NotifyType.DM_SINGLE_CHANNEL_GUESTS ? `${singleChannelGuestsMessaged} single-channel guests in` : ""
-  } channels ${channelSet
+  } channel(s) ${channelSet
     .values()
     .map((c) => `\`${c.name}\``)
     .join(", ")} about message \`${messageUrl}\``;
@@ -119,7 +119,9 @@ export function parseNotifyCommand(command: string): NotifyParameters {
   const tokens = command.split(" ");
 
   if (tokens.length == 1 && tokens[0].trim() == "") {
-    throw new Error("Please provide a message to send. Usage: `/notify <messageURL>`");
+    throw new Error(
+      "Please provide a message to send. Usage: `/notify LINK {copy | copy-ping} [default] [#channel1 #channel2 …]`",
+    );
   }
 
   // Check if first token is a valid URL

--- a/src/types/EventMetadata.ts
+++ b/src/types/EventMetadata.ts
@@ -12,4 +12,8 @@ export type EventMetadata = {
    * The meeting link for the event, if it exists
    */
   meetingLink?: string;
+  /**
+   * Whether to notify single channel guests in the default channels for this event
+   */
+  DMSingleChannelGuests: boolean;
 };

--- a/src/utils/calendarDescription.ts
+++ b/src/utils/calendarDescription.ts
@@ -81,7 +81,7 @@ export function parseDescription(
     return { description: descriptionText };
   }
 
-  // If channel not found, the meeting url is prepended to the description
+  // If description contains no line with channel, the meeting url is prepended to the description
   if (channelLine == undefined) {
     return { description: `${meetingLink}\n${descriptionText}` };
   }

--- a/src/utils/calendarDescription.ts
+++ b/src/utils/calendarDescription.ts
@@ -11,7 +11,7 @@ import { filterSlackChannelFromName } from "../utils/channels";
  */
 export function splitDescription(description: string): {
   descriptionText: string;
-  channels?: string;
+  channelLine?: string;
   meetingLink?: string;
 } {
   // Split the description by line
@@ -19,13 +19,13 @@ export function splitDescription(description: string): {
   // If there are multiple lines, the first 1-2 lines can contain the metadata
   // Check the first two lines for this metadata
   let descriptionStartLineNumber = 0;
-  let channels: string | undefined;
+  let channelLine: string | undefined;
   let meetingLink: string | undefined;
 
   for (let i = 0; i < Math.min(lines.length, 2); i++) {
     // If one of the first two lines starts with `#`, it is the channel
     if (lines[i].startsWith("#")) {
-      channels = lines[i].replace("#", "").trim();
+      channelLine = lines[i].replace("#", "").trim();
       descriptionStartLineNumber = i + 1;
     }
     // If one of the first two lines is a valid URL it is the meeting link
@@ -40,7 +40,7 @@ export function splitDescription(description: string): {
 
   return {
     descriptionText,
-    channels,
+    channelLine,
     meetingLink,
   };
 }
@@ -74,7 +74,7 @@ export function parseDescription(
   workspaceChannels: SlackChannel[],
 ): { description: string; minervaEventMetadata?: EventMetadata } {
   const plainDescription = parseDescriptionFromHtml(description);
-  const { descriptionText, channels: channelLine, meetingLink } = splitDescription(plainDescription);
+  const { descriptionText, channelLine, meetingLink } = splitDescription(plainDescription);
 
   // Short-circuit if there is no metadata
   if (channelLine == undefined && meetingLink == undefined) {

--- a/src/utils/calendarDescription.ts
+++ b/src/utils/calendarDescription.ts
@@ -88,7 +88,7 @@ export function parseDescription(
   const [channelName, ...modifiers] = channelLine.split(" ");
 
   const channel = filterSlackChannelFromName(channelName, workspaceChannels);
-  if (channel == undefined) throw new Error(`channel "${channelLine}" not found`);
+  if (channel == undefined) throw new Error(`channel "${channelName}" not found`);
 
   const minervaEventMetadata = {
     channel,

--- a/src/utils/calendarDescription.ts
+++ b/src/utils/calendarDescription.ts
@@ -81,8 +81,9 @@ export function parseDescription(
     return { description: descriptionText };
   }
 
+  // If channel not found, the meeting url is prepended to the description
   if (channelLine == undefined) {
-    throw new Error("channel name not specified");
+    return { description: `${meetingLink}\n${descriptionText}` };
   }
 
   const [channelName, ...modifiers] = channelLine.split(" ");

--- a/src/utils/eventReminders.ts
+++ b/src/utils/eventReminders.ts
@@ -98,13 +98,17 @@ export async function remindUpcomingEvent(
   }
 
   const DmReminderText = generateEventReminderDMText(messageUrl);
-  const singleChannelGuestsMessaged = await postReminderToDMs(
-    client,
-    channel,
-    DmReminderText,
-    defaultSlackChannels,
-    allSlackUsersInWorkspace,
-  );
+  // If event is not set up to DM single channel guests, singleChannelGuestsMessaged will be -1 to indicate that it was not messaged
+  let singleChannelGuestsMessaged = -1;
+  if (event.minervaEventMetadata.DMSingleChannelGuests) {
+    singleChannelGuestsMessaged = await postReminderToDMs(
+      client,
+      channel,
+      DmReminderText,
+      defaultSlackChannels,
+      allSlackUsersInWorkspace,
+    );
+  }
 
   const reminderTypeStrings = {
     [EventReminderType.MANUAL]: "manually triggered",
@@ -116,9 +120,9 @@ export async function remindUpcomingEvent(
   SlackLogger.getInstance().info(
     `Sent ${reminderTypeStrings[reminderType]} reminder for event \`${
       event.title
-    }\` at \`${event.start.toISOString()}\` to channel \`${
-      event.minervaEventMetadata.channel.name
-    }\` and ${singleChannelGuestsMessaged} single channel guests`,
+    }\` at \`${event.start.toISOString()}\` to channel \`${event.minervaEventMetadata.channel.name}\` ${
+      singleChannelGuestsMessaged != -1 ? `and ${singleChannelGuestsMessaged} single channel guests` : ""
+    }`,
   );
 }
 

--- a/src/utils/eventReminders.ts
+++ b/src/utils/eventReminders.ts
@@ -97,10 +97,10 @@ export async function remindUpcomingEvent(
     return;
   }
 
-  const DmReminderText = generateEventReminderDMText(messageUrl);
   // If event is not set up to DM single channel guests, singleChannelGuestsMessaged will be -1 to indicate that it was not messaged
   let singleChannelGuestsMessaged = -1;
   if (event.minervaEventMetadata.DMSingleChannelGuests) {
+    const DmReminderText = generateEventReminderDMText(messageUrl);
     singleChannelGuestsMessaged = await postReminderToDMs(
       client,
       channel,

--- a/src/utils/eventReminders.ts
+++ b/src/utils/eventReminders.ts
@@ -216,10 +216,12 @@ export async function remindUpcomingEvents(client: WebClient, events: CalendarEv
   const defaultSlackChannels = await getDefaultSlackChannels(client);
   const allSlackUsersInWorkspace = await getAllSlackUsers(client);
 
-  events.forEach((event) => {
-    const reminderType = getEventReminderType(event);
-    remindUpcomingEvent(event, client, reminderType, defaultSlackChannels, allSlackUsersInWorkspace);
-  });
+  events
+    .filter((event) => event.minervaEventMetadata != undefined)
+    .forEach((event) => {
+      const reminderType = getEventReminderType(event);
+      remindUpcomingEvent(event, client, reminderType, defaultSlackChannels, allSlackUsersInWorkspace);
+    });
 }
 
 /**

--- a/tests/unit/classes/CalendarEvent.test.ts
+++ b/tests/unit/classes/CalendarEvent.test.ts
@@ -13,6 +13,7 @@ describe("classes/CalendarEvent", () => {
         minervaEventMetadata: {
           channel: slackChannels[0],
           meetingLink: "https://example.com",
+          DMSingleChannelGuests: true,
         },
         location: googleCalendarEvent.location,
         start: new Date(googleCalendarEvent.start.dateTime),

--- a/tests/unit/commands/notifyCommand.test.ts
+++ b/tests/unit/commands/notifyCommand.test.ts
@@ -139,7 +139,7 @@ describe("parseNotifyCommand", () => {
   it("throws an error when the command is empty", () => {
     const commandArgs = "";
     expect(() => parseNotifyCommand(commandArgs)).toThrow(
-      "Please provide a message to send. Usage: `/notify <messageURL>`",
+      "Please provide a message to send. Usage: `/notify LINK {copy | copy-ping} [default] [#channel1 #channel2 …]`",
     );
   });
 

--- a/tests/unit/utils/calendarDescription.test.ts
+++ b/tests/unit/utils/calendarDescription.test.ts
@@ -9,7 +9,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "This is a description",
-        channelName: slackChannels[0].name,
+        channels: slackChannels[0].name,
         meetingLink: "https://example.com",
       });
     });
@@ -18,7 +18,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "This is a description",
-        channelName: slackChannels[0].name,
+        channels: slackChannels[0].name,
         meetingLink: "https://example.com",
       });
     });
@@ -41,7 +41,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "This is a description\nWith multiple lines",
-        channelName: slackChannels[0].name,
+        channels: slackChannels[0].name,
         meetingLink: "https://example.com",
       });
     });
@@ -50,7 +50,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "This is a description",
-        channelName: slackChannels[0].name,
+        channels: slackChannels[0].name,
       });
     });
     it("should split the description containing just channel and meeting link", () => {
@@ -58,7 +58,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "",
-        channelName: slackChannels[0].name,
+        channels: slackChannels[0].name,
         meetingLink: "https://example.com",
       });
     });
@@ -67,7 +67,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "",
-        channelName: slackChannels[0].name,
+        channels: slackChannels[0].name,
       });
     });
     it("should handle an empty description properly", () => {
@@ -82,7 +82,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "This is a description\n#sotruebestie",
-        channelName: slackChannels[0].name,
+        channels: slackChannels[0].name,
       });
     });
     it("should parse the metadata values even if they are out of order", () => {
@@ -90,7 +90,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "This is a description",
-        channelName: slackChannels[0].name,
+        channels: slackChannels[0].name,
         meetingLink: "https://example.com",
       });
     });
@@ -137,9 +137,24 @@ describe("utils/calendarDescription", () => {
         minervaEventMetadata: {
           channel: slackChannels[0],
           meetingLink: "https://example.com",
+          DMSingleChannelGuests: true,
         },
       });
     });
+
+    it("should parse the no-dm modifier", () => {
+      const description = `#${slackChannels[0].name} no-dm<br><a href="https://example.com">https://example.com</a><br>This is a description<br>Yep it is.`;
+      const result = parseDescription(description, slackChannels);
+      expect(result).toEqual({
+        description: "This is a description\nYep it is.",
+        minervaEventMetadata: {
+          channel: slackChannels[0],
+          meetingLink: "https://example.com",
+          DMSingleChannelGuests: false,
+        },
+      });
+    });
+
     it("should parse the description when metadata does not exist", () => {
       const description = `This is a description<br>Yep it is.`;
       const result = parseDescription(description, slackChannels);
@@ -154,6 +169,7 @@ describe("utils/calendarDescription", () => {
         description: "This is a description\nYep it is.",
         minervaEventMetadata: {
           channel: slackChannels[0],
+          DMSingleChannelGuests: true,
         },
       });
     });

--- a/tests/unit/utils/calendarDescription.test.ts
+++ b/tests/unit/utils/calendarDescription.test.ts
@@ -181,7 +181,10 @@ describe("utils/calendarDescription", () => {
 
     it("should throw an error if no channel is specified", () => {
       const description = `<a href="https://example.com">https://example.com</a><br>This is a description<br>Yep it is.`;
-      expect(() => parseDescription(description, slackChannels)).toThrow("channel name not specified");
+      const result = parseDescription(description, slackChannels);
+      expect(result).toEqual({
+        description: "https://example.com\nThis is a description\nYep it is.",
+      });
     });
   });
 });

--- a/tests/unit/utils/calendarDescription.test.ts
+++ b/tests/unit/utils/calendarDescription.test.ts
@@ -9,7 +9,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "This is a description",
-        channels: slackChannels[0].name,
+        channelLine: slackChannels[0].name,
         meetingLink: "https://example.com",
       });
     });
@@ -18,7 +18,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "This is a description",
-        channels: slackChannels[0].name,
+        channelLine: slackChannels[0].name,
         meetingLink: "https://example.com",
       });
     });
@@ -41,7 +41,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "This is a description\nWith multiple lines",
-        channels: slackChannels[0].name,
+        channelLine: slackChannels[0].name,
         meetingLink: "https://example.com",
       });
     });
@@ -50,7 +50,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "This is a description",
-        channels: slackChannels[0].name,
+        channelLine: slackChannels[0].name,
       });
     });
     it("should split the description containing just channel and meeting link", () => {
@@ -58,7 +58,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "",
-        channels: slackChannels[0].name,
+        channelLine: slackChannels[0].name,
         meetingLink: "https://example.com",
       });
     });
@@ -67,7 +67,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "",
-        channels: slackChannels[0].name,
+        channelLine: slackChannels[0].name,
       });
     });
     it("should handle an empty description properly", () => {
@@ -82,7 +82,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "This is a description\n#sotruebestie",
-        channels: slackChannels[0].name,
+        channelLine: slackChannels[0].name,
       });
     });
     it("should parse the metadata values even if they are out of order", () => {
@@ -90,7 +90,7 @@ describe("utils/calendarDescription", () => {
       const result = splitDescription(description);
       expect(result).toEqual({
         descriptionText: "This is a description",
-        channels: slackChannels[0].name,
+        channelLine: slackChannels[0].name,
         meetingLink: "https://example.com",
       });
     });

--- a/tests/unit/utils/googleCalendar.test.ts
+++ b/tests/unit/utils/googleCalendar.test.ts
@@ -15,6 +15,7 @@ describe("utils/googleCalendar", () => {
           minervaEventMetadata: {
             channel: slackChannels[0],
             meetingLink: "https://example.com",
+            DMSingleChannelGuests: true,
           },
           location: googleCalendarEvent.location,
           start: new Date(googleCalendarEvent.start.dateTime),
@@ -34,6 +35,7 @@ describe("utils/googleCalendar", () => {
     event.minervaEventMetadata = {
       channel: slackChannels[0],
       meetingLink: "https://example.com",
+      DMSingleChannelGuests: true,
     };
 
     it("should parse a Google Calendar event with one channel specified", () => {


### PR DESCRIPTION
## Description
<!-- Add background/context for the PR (why are we making these changes?) and a description of the changes that this makes. -->
Implemented a `no-dm` "modifier" that can be passed after the channel name for a minerva event to indicate that it should not DM single-channel guests about the event, i.e. the reminder will be sent to the specified channel and nowhere else.

<!-- Replace "00" with the relevant GitHub issue number. -->
<!-- e.g. https://github.com/waterloo-rocketry/minerva-rewrite/issues/44 has issue #44 -->

## Developer Testing
<!-- Outline steps that you have taken to test your newly implemented functionality. e.g. implementing new unit tests, steps taken for manual testing, etc. -->
Testing done:
- Implemented unit tests to ensure expected functionality

## Reviewer Testing
<!-- Provide some steps that reviewers can take to test your functionality (or just view the new feature) on their side.  -->
<!-- Note that much of minerva's functionality needs to be tested on the Dev Slack, so you should write these steps accordingly -->
Create a new calendar event in the development slack with the new `no-dm` flag specified after the channel name (e.g. for the first line of the event description, pass #temp no-dm) and ensure that when the meeting reminder is triggered (using /meeting_reminder should be fine) that the workspace's admins (stand-ins for single-channel guests) don't get DM'd

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/72)
<!-- Reviewable:end -->
