### PR TITLE
Fix race condition when adding multiple reactions to six-hour reminder message

### DIFF
--- a/src/utils/eventReminders.ts
+++ b/src/utils/eventReminders.ts
@@ -161,16 +161,18 @@ export async function postReminderToChannel(
   const timestamp = res.ts;
 
   if (reactEmojis !== undefined) {
-    reactEmojis.forEach(async (emoji) => {
-      try {
-        await addReactionToMessage(client, channel.id, emoji, timestamp);
-      } catch (error) {
-        SlackLogger.getInstance().error(
-          `Failed to add reaction \`${emoji}\` to message \`${timestamp}\` in \`${channel.name}\` with error:`,
-          error,
-        );
-      }
-    });
+    try {
+      const [emoji1, emoji2] = reactEmojis;
+      await addReactionToMessage(client, channel.id, emoji1, timestamp);
+      // Add small manual delay to ensure sequential reactions
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      await addReactionToMessage(client, channel.id, emoji2, timestamp);
+    } catch (error) {
+      SlackLogger.getInstance().error(
+        `Failed to add reactions \`${reactEmojis}\` to message \`${timestamp}\` in \`${channel.name}\` with error:`,
+        error,
+      );
+    }
   }
   const messageUrl = getMessagePermalink(client, channel.id, res.ts);
   return messageUrl;

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -184,7 +184,7 @@ export async function getChannelMembers(client: WebClient, channelId: string): P
  * @param timestamp The timestamp of the message to react to, as a string or number.
  * @returns A promise that resolves to the response from the Slack API.
  */
-export function addReactionToMessage(
+export async function addReactionToMessage(
   client: WebClient,
   channel: string,
   emoji: string,
@@ -194,7 +194,7 @@ export function addReactionToMessage(
   const timestampStr = typeof timestamp === "number" ? timestamp.toString() : timestamp;
 
   try {
-    return client.reactions.add({
+    return await client.reactions.add({
       channel,
       name: emoji,
       timestamp: timestampStr,


### PR DESCRIPTION
## Description
<!-- Add background/context for the PR (why are we making these changes?) and a description of the changes that this makes. -->
Fixed an issue where "react if coming or not" reaction emojis on six-hour reminder messages would not be added to the message in the right order. This was caused by the two calls to `addReactionToMessage` being too close to each other and therefore resulting in a race condition. Fix is to add a small manual delay in between.

<!-- Replace "00" with the relevant GitHub issue number. -->
<!-- e.g. https://github.com/waterloo-rocketry/minerva-rewrite/issues/44 has issue #44 -->

## Developer Testing
<!-- Outline steps that you have taken to test your newly implemented functionality. e.g. implementing new unit tests, steps taken for manual testing, etc. -->
Testing done:
- Manually tested on the development slack workspace

## Reviewer Testing
- N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/74)
<!-- Reviewable:end -->
