### PR TITLE
Fix issues relating to emoji seeding for reminder messages

### DIFF
--- a/src/utils/eventReminders.ts
+++ b/src/utils/eventReminders.ts
@@ -2,9 +2,9 @@ import { WebClient, ChatPostMessageResponse } from "@slack/web-api";
 import moment from "moment-timezone";
 
 import CalendarEvent from "../classes/CalendarEvent";
-import { postMessage, addReactionToMessage, getMessagePermalink, getAllSlackUsers } from "./slack";
+import { postMessage, getMessagePermalink, getAllSlackUsers } from "./slack";
 import { getDefaultSlackChannels } from "./channels";
-import { generateEmojiPair } from "./slackEmojis";
+import { generateEmojiPair, seedMessageReactions } from "./slackEmojis";
 import SlackChannel from "../classes/SlackChannel";
 import SlackUser from "../classes/SlackUser";
 import { postMessageToSingleChannelGuestsInChannels } from "./users";
@@ -160,13 +160,9 @@ export async function postReminderToChannel(
 
   const timestamp = res.ts;
 
-  if (reactEmojis !== undefined) {
+  if (reactEmojis != undefined && reactEmojis.length > 0) {
     try {
-      const [emoji1, emoji2] = reactEmojis;
-      await addReactionToMessage(client, channel.id, emoji1, timestamp);
-      // Add small manual delay to ensure sequential reactions
-      await new Promise((resolve) => setTimeout(resolve, 250));
-      await addReactionToMessage(client, channel.id, emoji2, timestamp);
+      await seedMessageReactions(client, channel.id, reactEmojis, timestamp);
     } catch (error) {
       SlackLogger.getInstance().error(
         `Failed to add reactions \`${reactEmojis}\` to message \`${timestamp}\` in \`${channel.name}\` with error:`,

--- a/src/utils/slackEmojis.ts
+++ b/src/utils/slackEmojis.ts
@@ -35,7 +35,7 @@ export async function seedMessageReactions(
   timestamp: string | number,
 ): Promise<void> {
   const response = await addReactionToMessage(client, channel, emojis[0], timestamp);
-
+  await new Promise((resolve) => setTimeout(resolve, 500));
   if (response.ok) {
     await addReactionToMessage(client, channel, emojis[1], timestamp);
   }


### PR DESCRIPTION
## Description
<!-- Add background/context for the PR (why are we making these changes?) and a description of the changes that this makes. -->
Fixed two small issues relating to minerva reminder message emoji seeding:
- #74 did not fix the race condition. Therefore, increasing the reaction delay and replacing the seeding logic with an already existing but unused function in the hopes that it fixes it.
- We were seeing erorrs being logged about messages unable to be reacted with `undefined`. Fixed the logic to check for undefined that was causing this issue

## Developer Testing
<!-- Outline steps that you have taken to test your newly implemented functionality. e.g. implementing new unit tests, steps taken for manual testing, etc. -->
Testing done:
- Manually tested on the dev slack. Due to the seemingly non-deterministic nature of the first issue, resolution might not be guaranteed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/75)
<!-- Reviewable:end -->
