### PR TITLE
Increase seedMessageReactions delay to 1 second

### DIFF
--- a/src/utils/slackEmojis.ts
+++ b/src/utils/slackEmojis.ts
@@ -35,8 +35,8 @@ export async function seedMessageReactions(
   timestamp: string | number,
 ): Promise<void> {
   const response = await addReactionToMessage(client, channel, emojis[0], timestamp);
-  await new Promise((resolve) => setTimeout(resolve, 500));
   if (response.ok) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     await addReactionToMessage(client, channel, emojis[1], timestamp);
   }
 }


### PR DESCRIPTION
## Description
<!-- Add background/context for the PR (why are we making these changes?) and a description of the changes that this makes. -->
Following #75, It seems that a 500ms delay between reactions for reaction seeding is insufficient to prevent the race condition in production. Therefore, increased the delay to 1 second, the same as for old minerva.

## Developer Testing
<!-- Outline steps that you have taken to test your newly implemented functionality. e.g. implementing new unit tests, steps taken for manual testing, etc. -->
Testing done:
- Manually tested on the dev slack. Due to the seemingly non-deterministic nature of the issue and the inconsistency in the issue appearing between the dev and prod environments, resolution might not be guaranteed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/76)
<!-- Reviewable:end -->
