### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @waterloo-rocketry/default-reviewers @QuantumManiac @PCModeActivate @slightlyskepticalpotat @yxyyeah @Panizghi @billyao021031 @shirleyfyx @jeffrey-huang-yz @wxp02
+* @waterloo-rocketry/default-reviewers
 


### PR DESCRIPTION
Title. None of the people in minerva's CODEOWNERS file (except for @slightlyskepticalpotat and @PCModeActivate - please let me know if you still want to review minerva PRs and I'll modify accordingly) are still in rocketry afaik.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/83)
<!-- Reviewable:end -->
