### PR TITLE
Enhance from dev branch PR for Cancelled Function

### DIFF
--- a/src/classes/CalendarEvent.ts
+++ b/src/classes/CalendarEvent.ts
@@ -14,7 +14,7 @@ export default class CalendarEvent {
   /**
    * Cancelled status of the event
    */
-  cancelled?: boolean;
+  is_cancelled: boolean;
   /**
    * The description of the event
    */
@@ -52,7 +52,7 @@ export default class CalendarEvent {
       throw new Error("Event summary is undefined");
     }
     const title = event.summary;
-    const cancelled = title.includes("CANCELLED");
+    const is_cancelled = title.toLowerCase().includes("cancelled");
     if (event.start?.dateTime == undefined) {
       throw new Error(`Event start is undefined for event "${event.summary}"`);
     }
@@ -66,11 +66,10 @@ export default class CalendarEvent {
     }
     const url = event.htmlLink;
 
-    const parsedEvent = new CalendarEvent(title, start, end, url);
+    const parsedEvent = new CalendarEvent(title, start, end, url, is_cancelled);
 
     parsedEvent.location = event.location ?? undefined;
     parsedEvent.url = event.htmlLink ?? undefined;
-    parsedEvent.cancelled = cancelled;
 
     if (event?.description != undefined) {
       try {
@@ -95,6 +94,7 @@ export default class CalendarEvent {
     start: Date,
     end: Date,
     url: string,
+    is_cancelled: boolean,
     description?: string,
     location?: string,
     minervaEventMetadata?: EventMetadata,
@@ -103,6 +103,7 @@ export default class CalendarEvent {
     this.start = start;
     this.end = end;
     this.url = url;
+    this.is_cancelled = is_cancelled;
     this.description = description;
     this.location = location;
     this.minervaEventMetadata = minervaEventMetadata;

--- a/src/utils/eventReminders.ts
+++ b/src/utils/eventReminders.ts
@@ -230,7 +230,7 @@ export async function remindUpcomingEvents(client: WebClient, events: CalendarEv
  */
 export function generateEventReminderChannelText(event: CalendarEvent, reminderType: EventReminderType): string {
   let message = `${
-    !event.cancelled &&
+    !event.is_cancelled &&
     (reminderType == EventReminderType.FIVE_MINUTES || reminderType == EventReminderType.MANUAL_PING)
       ? "<!channel>\n"
       : ""

--- a/tests/fixtures/googleCalendarEvent.json
+++ b/tests/fixtures/googleCalendarEvent.json
@@ -7,7 +7,7 @@
   "created": "2023-12-02T19:33:17.000Z",
   "updated": "2023-12-07T15:33:49.949Z",
   "location": "The Bay",
-  "summary": "[CANCELLED] Minerva Testing",
+  "summary": "Minerva Testing",
   "description": "#admin<br><a href=\"https://example.com\">https://example.com</a><br>This is a description<br>Yep it is.",
   "creator": {
     "email": "test.creator@gmail.com"

--- a/tests/fixtures/googleCalendarEvents.json
+++ b/tests/fixtures/googleCalendarEvents.json
@@ -22,7 +22,7 @@
       "created": "2023-12-02T19:33:17.000Z",
       "updated": "2023-12-07T15:33:49.949Z",
       "location": "The Bay",
-      "summary": "[CANCELLED] Minerva Testing",
+      "summary": "Minerva Testing",
       "description": "#admin<br><a href=\"https://example.com\">https://example.com</a><br>This is a description<br>Yep it is.",
       "creator": {
         "email": "test.creator@gmail.com"

--- a/tests/unit/classes/CalendarEvent.test.ts
+++ b/tests/unit/classes/CalendarEvent.test.ts
@@ -8,7 +8,7 @@ describe("classes/CalendarEvent", () => {
       const calendarEvent = CalendarEvent.fromGoogleCalendarEvent(googleCalendarEvent, slackChannels);
       expect(calendarEvent).toEqual({
         title: googleCalendarEvent.summary,
-        cancelled: true,
+        is_cancelled: false,
         url: googleCalendarEvent.htmlLink,
         description: "This is a description\nYep it is.",
         minervaEventMetadata: {
@@ -22,13 +22,22 @@ describe("classes/CalendarEvent", () => {
       });
     });
 
+    it("should create a cancelled CalendarEvent from a Google Calendar event", () => {
+      const cancelledEvent = {
+        ...googleCalendarEvent,
+        summary: "[Cancelled]" + googleCalendarEvent.summary,
+      };
+      const calendarEvent = CalendarEvent.fromGoogleCalendarEvent(cancelledEvent, slackChannels);
+      expect(calendarEvent.is_cancelled).toBe(true);
+    });
+
     it("should create a CalendarEvent from a Google Calendar event when there's no metadata", () => {
       const calendarEventJson = JSON.parse(JSON.stringify(googleCalendarEvent));
       calendarEventJson.description = "This is a description<br>Yep it is.";
       const calendarEvent = CalendarEvent.fromGoogleCalendarEvent(calendarEventJson, slackChannels);
       expect(calendarEvent).toEqual({
         title: googleCalendarEvent.summary,
-        cancelled: true,
+        is_cancelled: false,
         url: googleCalendarEvent.htmlLink,
         description: "This is a description\nYep it is.",
         location: googleCalendarEvent.location,

--- a/tests/unit/utils/googleCalendar.test.ts
+++ b/tests/unit/utils/googleCalendar.test.ts
@@ -10,7 +10,7 @@ describe("utils/googleCalendar", () => {
       expect(parseEvents(googleCalendarEvents, slackChannels)).toEqual([
         {
           title: googleCalendarEvent.summary,
-          cancelled: true,
+          is_cancelled: false,
           url: googleCalendarEvent.htmlLink,
           description: "This is a description\nYep it is.",
           minervaEventMetadata: {
@@ -23,6 +23,15 @@ describe("utils/googleCalendar", () => {
           end: new Date(googleCalendarEvent.end.dateTime),
         },
       ]);
+    });
+
+    it("should parse a cancelled Google Calendar event", () => {
+      const cancelledEvent = {
+        ...googleCalendarEvent,
+        summary: "[cancelled]" + googleCalendarEvent.summary,
+      };
+      const parsedEvent = parseEvents({ items: [cancelledEvent] }, slackChannels)[0];
+      expect(parsedEvent.is_cancelled).toBe(true);
     });
 
     it("should ignore all-day events", () => {


### PR DESCRIPTION
This pull request includes updates to the `README.md` file and several changes to the `CalendarEvent` class and associated functionality to handle cancelled events. It also includes updates to the unit tests to ensure the new functionality is properly tested.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R24): Added links to Google Drive documents for usage and development guides.

### CalendarEvent class enhancements:
* [`src/classes/CalendarEvent.ts`](diffhunk://#diff-bdf91ea31483ddf503373dc055ca4fa8cad7181eff47ebbb8da7e11fbc6f371eR14-R17): Added `is_cancelled` property to the `CalendarEvent` class and updated the constructor and `fromGoogleCalendarEvent` method to handle cancelled events. [[1]](diffhunk://#diff-bdf91ea31483ddf503373dc055ca4fa8cad7181eff47ebbb8da7e11fbc6f371eR14-R17) [[2]](diffhunk://#diff-bdf91ea31483ddf503373dc055ca4fa8cad7181eff47ebbb8da7e11fbc6f371eR55) [[3]](diffhunk://#diff-bdf91ea31483ddf503373dc055ca4fa8cad7181eff47ebbb8da7e11fbc6f371eL64-R69) [[4]](diffhunk://#diff-bdf91ea31483ddf503373dc055ca4fa8cad7181eff47ebbb8da7e11fbc6f371eR97) [[5]](diffhunk://#diff-bdf91ea31483ddf503373dc055ca4fa8cad7181eff47ebbb8da7e11fbc6f371eR106)

### Reminder functionality:
* [`src/utils/eventReminders.ts`](diffhunk://#diff-779296dacd28055738f8fa2363732c33be2c0fa60ae67834608ab9f511ad46b6L233-R234): Updated the `generateEventReminderChannelText` function to skip reminders for cancelled events.

### Unit test updates:
* [`tests/unit/classes/CalendarEvent.test.ts`](diffhunk://#diff-ac5e97e7482ecc0519d2ac62e039d2e3ff84d0dec7633486b17648cb7df14c90R11): Added tests to verify the handling of cancelled events in the `CalendarEvent` class. [[1]](diffhunk://#diff-ac5e97e7482ecc0519d2ac62e039d2e3ff84d0dec7633486b17648cb7df14c90R11) [[2]](diffhunk://#diff-ac5e97e7482ecc0519d2ac62e039d2e3ff84d0dec7633486b17648cb7df14c90R25-R40)
* [`tests/unit/utils/googleCalendar.test.ts`](diffhunk://#diff-6fa5aadbfa7ada1c0232949b7a90a265ff60d947009ae93eda234ea5a18da3f4R13): Added tests to verify the parsing of cancelled events from Google Calendar. [[1]](diffhunk://#diff-6fa5aadbfa7ada1c0232949b7a90a265ff60d947009ae93eda234ea5a18da3f4R13) [[2]](diffhunk://#diff-6fa5aadbfa7ada1c0232949b7a90a265ff60d947009ae93eda234ea5a18da3f4R28-R36)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/84)
<!-- Reviewable:end -->
