### PR TITLE
refactor: simplify event reminder message construction

### DIFF
--- a/src/utils/eventReminders.ts
+++ b/src/utils/eventReminders.ts
@@ -234,17 +234,21 @@ export function generateEventReminderChannelText(event: CalendarEvent, reminderT
     (reminderType == EventReminderType.FIVE_MINUTES || reminderType == EventReminderType.MANUAL_PING)
       ? "<!channel>\n"
       : ""
-  }Reminder: *${event.title}* is occurring`;
+  }Reminder: *${event.title}*`;
+
+  let timeUntilEventMessage: string;
 
   if (reminderType === EventReminderType.FIVE_MINUTES) {
     const timeUntilEvent = event.start.getTime() - new Date().getTime();
-    message += ` in *${Math.ceil(timeUntilEvent / 1000 / 60)} minutes*`;
+    timeUntilEventMessage = `in *${Math.ceil(timeUntilEvent / 1000 / 60)} minutes*`;
   } else {
-    message += ` at *${moment(event.start).tz("America/Toronto").format("MMMM Do, YYYY [at] h:mm A")}*`;
+    timeUntilEventMessage = `at *${moment(event.start).tz("America/Toronto").format("MMMM Do, YYYY [at] h:mm A")}*`;
   }
 
   if (event.is_cancelled) {
-    message += " has been cancelled";
+    message += ` that was supposed to occur ${timeUntilEventMessage} *has been cancelled*`;
+  } else {
+    message += ` is occurring ${timeUntilEventMessage}`;
   }
 
   if (event.url) {


### PR DESCRIPTION
This pull request includes a change to the `generateEventReminderChannelText` function in the `src/utils/eventReminders.ts` file. The main purpose of this change is to refactor how the event reminder message is constructed, improving readability and maintainability.

Refactoring of `generateEventReminderChannelText`:

* Extracted the time until event message into a separate variable `timeUntilEventMessage` to enhance readability and maintainability.
* Modified the concatenation logic to include `timeUntilEventMessage` in both the event occurring and event cancellation scenarios.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva-rewrite/86)
<!-- Reviewable:end -->
